### PR TITLE
Update README to indicate this Helm chart is no longer maintained.

### DIFF
--- a/charts/timescaledb-multinode/README.md
+++ b/charts/timescaledb-multinode/README.md
@@ -3,6 +3,14 @@ This file and its contents are licensed under the Apache License 2.0.
 Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 -->
 
+# Call for Maintainers
+
+This Helm chart will no longer maintained by the Timescale team going forward.
+We are looking for some awesome community maintainers who are interested in
+becoming maintainers and contributors.  For now please use the
+[timescaledb-single](https://github.com/timescale/helm-charts/tree/master/charts/timescaledb-single)
+chart going forward.
+
 # TimescaleDB Multinode
 
 This directory contains a Helm chart to deploy a multinode [TimescaleDB](https://github.com/timescale/timescaledb/) cluster.


### PR DESCRIPTION
Update `README.md` to show that the multinode Helm chart is no longer being maintained.