### PR TITLE
charts/timescaledb-multinode: deprecate chart

### DIFF
--- a/charts/timescaledb-multinode/Chart.yaml
+++ b/charts/timescaledb-multinode/Chart.yaml
@@ -18,3 +18,7 @@ sources:
 maintainers:
 - name: TimescaleDB
   email: support@timescale.com
+
+# The chart is deprecated. We are looking for maintainers to remove this field.
+# More in https://github.com/timescale/helm-charts/blob/master/charts/timescaledb-multinode/README.md#call-for-maintainers
+deprecated: true

--- a/charts/timescaledb-multinode/requirements.yaml
+++ b/charts/timescaledb-multinode/requirements.yaml
@@ -1,4 +1,0 @@
-# This file and its contents are licensed under the Apache License 2.0.
-# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
-
-dependencies: []


### PR DESCRIPTION
Follow-up to https://github.com/timescale/helm-charts/pull/409