### PR TITLE
Add a helm chart for Avalanche

### DIFF
--- a/charts/avalanche/Chart.yaml
+++ b/charts/avalanche/Chart.yaml
@@ -20,5 +20,3 @@ keywords:
 - monitoring
 - benchmarking
 - prometheus
-
-

--- a/charts/avalanche/Chart.yaml
+++ b/charts/avalanche/Chart.yaml
@@ -1,0 +1,24 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+apiVersion: v2
+name: avalanche
+description: A Helm chart run avalanche for benchmarking Prometheus and remote write storage backends.
+version: 0.1.0
+
+home: https://github.com/timescale/helm-charts
+
+sources:
+- https://github.com/timescale/helm-charts
+- https://github.com/prometheus-community/avalanche
+
+maintainers:
+- name: timescale
+  url: https://www.timescale.com/
+
+keywords:
+- monitoring
+- benchmarking
+- prometheus
+
+

--- a/charts/avalanche/README.md
+++ b/charts/avalanche/README.md
@@ -1,0 +1,54 @@
+<!---
+This file and its contents are licensed under the Apache License 2.0.
+Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+-->
+
+# Avalanche
+
+##### Table of Contents
+- [Introduction](#introduction)
+- [Installation](#installation)
+  - [Installing from the Timescale Helm Repo](#installing-from-the-timescale-helm-repo)
+
+## Introduction
+This directory contains a Helm chart to deploy [Avalanche](https://github.com/prometheus-community/avalanche),
+used for load testing and benchmarking Prometheus and remote write compatible storage backends such as Promscale.
+
+## Installation
+
+To install the chart with the release name `my-release` You can install the chart with:
+```console
+helm install --name my-release charts/avalanche
+```
+
+You can override parameters using the `--set key=value[,key=value]` argument to `helm install`,
+e.g., to disable service account creation:
+
+```console
+helm install --name my-release charts/avalanche --set serviceAccount.create=false
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+```console
+helm install --name my-release -f myvalues.yaml charts/avalanche
+```
+
+### Installing from the Timescale Helm Repo
+
+We have a Helm Repository that you can use, instead of cloning this Git repo. 
+
+First add the repository with:
+```console
+helm repo add timescale 'https://charts.timescale.com'
+```
+
+Next proceed to install the chart:
+
+```console
+helm install my-release timescale/avalanche
+```
+
+To keep the repo up to date with new versions you can do:
+```console
+helm repo update
+```

--- a/charts/avalanche/ci/default-values.yaml
+++ b/charts/avalanche/ci/default-values.yaml
@@ -1,0 +1,10 @@
+# Arguments that will be passed onto deployment pods
+# The list of available cli flags can be found by
+# running avalanche --help
+extraArgs:
+  - --metric-count=1
+  - --series-count=1000
+  - --remote-url=http://test-promscale.tobs-test.svc:9201/write
+  - --remote-write-interval=30s
+
+readinessProbe: null

--- a/charts/avalanche/templates/_helpers.tpl
+++ b/charts/avalanche/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+This file and its contents are licensed under the Apache License 2.0.
+Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "avalanche.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "avalanche.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "avalanche.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "avalanche.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "avalanche.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate common labels to be used
+*/}}
+{{- define "avalanche.labels" -}}
+app: {{ include "avalanche.fullname" . }}
+chart: {{ template "avalanche.chart" . }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+{{- end }}
+
+{{- define "avalanche-helm.labels" -}}
+{{ include "avalanche.labels" . }}
+app.kubernetes.io/name: {{ include "avalanche.fullname" . | quote }}
+app.kubernetes.io/version: {{ .Chart.Version }}
+{{- end }}

--- a/charts/avalanche/templates/deployment-avalanche.yaml
+++ b/charts/avalanche/templates/deployment-avalanche.yaml
@@ -1,0 +1,49 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "avalanche.fullname" . }}
+  labels:
+{{ include "avalanche-helm.labels" . | indent 4 }}
+    app.kubernetes.io/component: avalanche
+  {{- if .Values.annotations }}
+  annotations: {{ toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: {{ template "avalanche.fullname" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ template "avalanche.fullname" . }}
+      labels:
+{{ include "avalanche-helm.labels" . | indent 8 }}
+        app.kubernetes.io/component: avalanche
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "avalanche.serviceAccountName" . }}
+      containers:
+        - name: avalanche
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --port==9001
+            {{- with .Values.extraArgs }}
+            {{ toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+          - containerPort: 9001
+            name: metrics
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/charts/avalanche/templates/deployment-avalanche.yaml
+++ b/charts/avalanche/templates/deployment-avalanche.yaml
@@ -13,8 +13,6 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  updateStrategy:
-    type: RollingUpdate
   selector:
     matchLabels:
       app: {{ template "avalanche.fullname" . }}
@@ -36,7 +34,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - --port==9001
+            - --port=9001
             {{- with .Values.extraArgs }}
             {{ toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/avalanche/templates/service-account.yaml
+++ b/charts/avalanche/templates/service-account.yaml
@@ -1,0 +1,12 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "avalanche.serviceAccountName" . }}
+  labels:
+{{ include "avalanche-helm.labels" . | indent 4}}
+    app.kubernetes.io/component: rbac
+{{- end }}

--- a/charts/avalanche/templates/service-monitor.yaml
+++ b/charts/avalanche/templates/service-monitor.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "avalanche.fullname" . }}
+  labels:
+{{ include "avalanche-helm.labels" . | indent 4 }}
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+{{ include "avalanche.labels" . | indent 6 }}
+{{- end }}

--- a/charts/avalanche/templates/svc-avalanche.yaml
+++ b/charts/avalanche/templates/svc-avalanche.yaml
@@ -1,0 +1,29 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "avalanche.fullname" . }}
+  labels:
+{{ include "avalanche-helm.labels" . | indent 4 }}
+    app.kubernetes.io/component: avalanche
+{{- if .Values.service.labels }}
+{{ .Values.service.labels | toYaml | indent 4 }}
+{{- end }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ .Values.service.annotations | toYaml | indent 4 }}
+{{- end }}
+spec:
+  selector:
+{{ include "avalanche.labels" . | indent 4}}
+  type: {{ .Values.service.type }}
+  ports:
+  - name: metrics
+    port: {{ .Values.service.port }}
+    targetPort: metrics
+    protocol: TCP
+{{- if .Values.service.spec }}
+{{ .Values.service.spec | toYaml | indent 2 }}
+{{- end }}

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -53,6 +53,9 @@ resources: {}
 #     - |-
 #       status_code=$(wget --server-response "http://${WEB_AUTH_USERNAME}:${WEB_AUTH_PASSWORD}@localhost:9001/health" 2>&1 | awk '/^  HTTP/{print $2}');
 #       if [[ "${status_code}" == "200" ]]; then exit 0; else exit 1; fi
+# NOTE: This readinessProbe will fail when remote_write is used, as avalanche
+# does not enable the healthcheck endpoint when remote write is used instead
+# of the /metrics endpoint.
 readinessProbe:
   httpGet:
     path: /health

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -1,0 +1,63 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+image:
+  repository: quay.io/prometheuscommunity/avalanche
+  tag: main
+  pullPolicy: IfNotPresent
+
+# number of connector pods to spawn
+replicaCount: 1
+
+# Arguments that will be passed onto deployment pods
+# The list of available cli flags can be found by
+# running avalanche --help
+extraArgs: []
+
+# Annotations to be added to the avalanche Deployment
+annotations: {}
+
+# Annotations to be added to the avalanche Pods
+podAnnotations: {}
+
+# Enable ServiceMonitor used by prometheus-operator to configure prometheus for metrics scraping.
+# Note that by enabling the service monitor, the cluster's Prometheus will start scraping the metrics
+# generated as load and intended for benchmarking.
+serviceMonitor:
+  enabled: false
+
+# settings for the service to be created that will expose
+# the avalanche deployment
+service:
+  type: "ClusterIP"
+  annotations: {}
+  port: 9001
+  # properties to be added to service.spec
+  spec: {}
+
+# create and attach a service account
+serviceAccount:
+  create: true
+  # name: custom-name
+
+# set your own limits
+resources: {}
+
+# set a custom readiness probe e.g. when basic auth is enabled
+# readinessProbe:
+#   httpGet: null
+#   exec:
+#     command:
+#     - sh
+#     - -c
+#     - |-
+#       status_code=$(wget --server-response "http://${WEB_AUTH_USERNAME}:${WEB_AUTH_PASSWORD}@localhost:9001/health" 2>&1 | awk '/^  HTTP/{print $2}');
+#       if [[ "${status_code}" == "200" ]]; then exit 0; else exit 1; fi
+readinessProbe:
+  httpGet:
+    path: /health
+    port: metrics
+    scheme: HTTP
+  failureThreshold: 3
+  timeoutSeconds: 15
+  periodSeconds: 15

--- a/charts/timescaledb-multinode/Chart.yaml
+++ b/charts/timescaledb-multinode/Chart.yaml
@@ -10,9 +10,9 @@ version: 0.8.0
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field
 # To avoid confusion, we will not expose appVersion
 # appVersion: 0.0.1
-home: https://github.com/timescale/timescaledb-kubernetes
+home: https://github.com/timescale/helm-charts
 sources:
-- https://github.com/timescale/timescaledb-kubernetes
+- https://github.com/timescale/helm-charts
 - https://github.com/timescale/timescaledb-docker-ha
 - https://github.com/zalando/patroni
 maintainers:

--- a/charts/timescaledb-multinode/Chart.yaml
+++ b/charts/timescaledb-multinode/Chart.yaml
@@ -15,9 +15,6 @@ sources:
 - https://github.com/timescale/helm-charts
 - https://github.com/timescale/timescaledb-docker-ha
 - https://github.com/zalando/patroni
-maintainers:
-- name: TimescaleDB
-  email: support@timescale.com
 
 # The chart is deprecated. We are looking for maintainers to remove this field.
 # More in https://github.com/timescale/helm-charts/blob/master/charts/timescaledb-multinode/README.md#call-for-maintainers

--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -10,9 +10,9 @@ version: 0.14.0
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field
 # To avoid confusion, we will not expose appVersion
 # appVersion: 0.0.1
-home: https://github.com/timescale/timescaledb-kubernetes
+home: https://github.com/timescale/helm-charts
 sources:
-- https://github.com/timescale/timescaledb-kubernetes
+- https://github.com/timescale/helm-charts
 - https://github.com/timescale/timescaledb-docker-ha
 - https://github.com/zalando/patroni
 maintainers:


### PR DESCRIPTION
The PR adds a helm chart for running avalanche, a tool to load test Prometheus and Remote Write compatible storage backends, such as Promscale.

This fixes timescale/sre-monitoring#63