### PR TITLE
Update default values for postgres_exporter and documentation

### DIFF
--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -75,8 +75,8 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `podManagementPolicy`             | Either [`OrderedReady` or `Parallel`](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) | `OrderedReady` |
 | `prometheus.enabled`              | If enabled, run a [postgres\_exporter](https://github.com/prometheus-community/postgres_exporter) sidecar | `false` |
 | `prometheus.image.pullPolicy`     | The pull policy for the postgres\_exporter  | `IfNotPresent`                                      |
-| `prometheus.image.repository`     | The postgres\_exporter docker repo          | `wrouesnel/postgres_exporter`                       |
-| `prometheus.image.tag`            | The tag of the postgres\_exporter image     | `v0.7.0`                                            |
+| `prometheus.image.repository`     | The postgres\_exporter docker repo          | `quay.io/prometheuscommunity/postgres_exporter`     |
+| `prometheus.image.tag`            | The tag of the postgres\_exporter image     | `v0.11.0`                                           |
 | `rbac.create`                     | Create required role and rolebindings       | `true`                                              |
 | `replicaCount`                    | Amount of pods to spawn                     | `3`                                                 |
 | `replicaLoadBalancer.annotations` | Deprecated(0.10.0): Pass on annotations to the Load Balancer | An AWS ELB annotation to increase the idle timeout |

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -37,7 +37,7 @@ secrets:
 
   # Selector used to provision your own Secret containing patroni configuration details
   # This is mutually exclusive with `credentials` option and takes precedence over it.
-  # WARNING: Use this option with caution  
+  # WARNING: Use this option with caution
   credentialsSecretName: ""
 
   # This map should contain tls key and certifiacte. When empty,
@@ -58,7 +58,7 @@ secrets:
     PGBACKREST_REPO1_S3_KEY_SECRET: ""
     PGBACKREST_REPO1_S3_BUCKET: ""
     PGBACKREST_REPO1_S3_ENDPOINT: "s3.amazonaws.com"
-  
+
   # Selector used to provision your own Secret containing pgbackrest configuration details
   # This is mutually exclusive with `pgbackrest` option and takes precedence over it.
   # WARNING: Use this option with caution
@@ -517,8 +517,8 @@ nodeSelector: {}
 prometheus:
   enabled: false
   image:
-    repository: prometheuscommunity/postgres-exporter
-    tag: v0.9.0
+    repository: quay.io/prometheuscommunity/postgres-exporter
+    tag: v0.11.0
     pullPolicy: Always
   # Extra custom environment variables for prometheus.
   # These should be an EnvVar, as this allows you to inject secrets into the environment


### PR DESCRIPTION
- Bump postgres_exporter to be inline to what we set inside tobs. 
- Update `admin-guide.md` to show new defaults for postgres_exporter.