### PR TITLE
Bugfix for issue #446 - podmonitor not working in timescaledb-single.

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.16.1
+version: 0.16.2
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/docs/admin-guide.md
+++ b/charts/timescaledb-single/docs/admin-guide.md
@@ -74,7 +74,6 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `pgBouncer.userListSecretName`    | If set, a [user authentication file](https://www.pgbouncer.org/config.html#authentication-file-format) to be used by pgBouncer. | `nil` |
 | `podManagementPolicy`             | Either [`OrderedReady` or `Parallel`](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) | `OrderedReady` |
 | `podMonitor.enabled`          | Enable deployment of podMonitor used with prometheus-operator. | `false` |
-| `podMonitor.portName`         | Name of the port (not number!) on which prometheus metrics are exposed. | `metrics` |
 | `podMonitor.path`             | Path on which prometheus metrics are exposed. | `/metrics` |
 | `podMonitor.interval`         | Prometheus scrape interval. Lower values increase resolution, higher values reduce prometheus memory consumption. Do not set over 2m. | `10s` |
 | `podMonitor.scrapeTimeout`    | Prometheus scrape timeout. Value cannot be lower than scrape interval. | `nil` |

--- a/charts/timescaledb-single/templates/podmonitor.yaml
+++ b/charts/timescaledb-single/templates/podmonitor.yaml
@@ -19,7 +19,7 @@ spec:
     scrapeTimeout: {{ .Values.podMonitor.scrapeTimeout }}
     {{- end }}
     honorLabels: true
-    port: {{ .Values.podMonitor.portName }}
+    port: pg-exporter
     path: {{ .Values.podMonitor.path }}
     {{- if .Values.podMonitor.metricRelabelings }}
     metricRelabelings: {{ toYaml .Values.podMonitor.metricRelabelings | nindent 6 }}
@@ -29,7 +29,6 @@ spec:
     matchLabels:
       app: {{ template "timescaledb.fullname" . }}
       release: "{{ .Release.Name }}"
-      component: postgres-exporter
   {{- if .Values.podMonitor.targetLabels }}
   targetLabels: {{ toYaml .Values.podMonitor.targetLabels | nindent 4 }}
   {{- end }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -550,7 +550,6 @@ prometheus:
 podMonitor:
   # Specifies whether PodMonitor for Prometheus operator should be created
   enabled: false
-  portName: metrics
   path: /metrics
   interval: 10s
   # scrapeTimeout: 30s


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This makes monitoring via prometheus/podmonitor work once again in the chart.

#### Which issue this PR fixes

#446 

#### Special notes for your reviewer

I'm open to other paths here, but this simple fix got me moving again.  I removed the value for `podMonitor.portName` because the portName is hard-coded in the statefulset and doesn't seem like a terribly useful thing to be able to override in the values.

I _don't know_ where the motivation came from for the "component" selector.  I could be missing something here.  It at least doesn't exist in my deployments of the chart.  I removed it here, but if you know of a reason it should exists sometimes I'm glad to chat about it.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
