### PR TITLE
Fix pod annotation indentation

### DIFF
--- a/charts/promscale/Chart.yaml
+++ b/charts/promscale/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: promscale
 description: Promscale Connector deployment
 
-version: 14.0.0
+version: 14.0.1
 appVersion: 0.14.0
 
 home: https://github.com/timescale/promscale

--- a/charts/promscale/templates/deployment-promscale.yaml
+++ b/charts/promscale/templates/deployment-promscale.yaml
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scrape: {{ not .Values.serviceMonitor.enabled | quote }}
         {{- if .Values.podAnnotations }}
         {{- range $key, $value := .Values.podAnnotations }}
-          {{ $key }}: {{ $value | quote }}
+        {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
     spec:


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Current pod annotation will result following result and make helm failed to deploy
<img width="759" alt="image" src="https://user-images.githubusercontent.com/1646270/189749795-c2eba2f8-1661-4c7a-aa2e-674cc32aa44b.png">


```
STDERR:
  Error: YAML parse error on xxx/charts/promscale/templates/deployment-promscale.yaml: error converting YAML to JSON: yaml: line 38: did not find expected key
  Use --debug flag to render out invalid YAML

```

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
