### PR TITLE
Update promscale to 0.14.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,10 +78,14 @@ jobs:
 
       - name: Check changed charts
         id: changed-charts
-        run: echo "::set-output name=charts::$(ct list-changed | grep promscale)"
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [ -n $changed ]; then
+            echo "::set-output  name=charts::${changed}"
+          fi
 
       - name: Pre-install DB
-        if: steps.changed-charts.outputs.charts != ''
+        if: steps.changed-charts.outputs.charts == 'charts/promscale'
         run: make install-db
 
       - name: Run e2e chart-testing

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ install-db:  ## Install the testing database into the local kubernetes kind clus
 		--set replicaCount=1 \
 		--set secrets.credentials.PATRONI_SUPERUSER_PASSWORD="temporarypassword" \
 		--set loadBalancer.enabled=false \
-		--set image.tag=pg14.4-ts2.7.2-p0
+		--set image.tag=pg14.5-ts2.8.0-p1
 
 .PHONY: e2e
 e2e: load-images  ## Run e2e installation tests using ct (chart-testing).

--- a/charts/promscale/Chart.yaml
+++ b/charts/promscale/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: promscale
 description: Promscale Connector deployment
 
-version: 13.0.0
-appVersion: 0.13.0
+version: 14.0.0
+appVersion: 0.14.0
 
 home: https://github.com/timescale/promscale
 sources:
-- https://github.com/timescale/promscale
-- https://github.com/timescale/helm-charts
+  - https://github.com/timescale/promscale
+  - https://github.com/timescale/helm-charts
 
 maintainers:
-- name: TimescaleDB
-  email: support@timescale.com
+  - name: TimescaleDB
+    email: support@timescale.com


### PR DESCRIPTION
#### What this PR does / why we need it
* Bump promscale version from `0.13.0` to `0.14.0`
* Bump chart version from `13.0.0` to `14.0.0`

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
