### PR TITLE
Allow mount extra volumes for config files

### DIFF
--- a/charts/promscale/Chart.yaml
+++ b/charts/promscale/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: promscale
 description: Promscale Connector deployment
 
-version: 13.0.0
+version: 13.1.0
 appVersion: 0.13.0
 
 home: https://github.com/timescale/promscale

--- a/charts/promscale/templates/deployment-promscale.yaml
+++ b/charts/promscale/templates/deployment-promscale.yaml
@@ -73,10 +73,16 @@ spec:
           volumeMounts:
             - name: configs
               mountPath: /etc/promscale/
+          {{- if .Values.extraVolumeMounts }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
       volumes:
         - name: configs
           configMap:
             name: {{ include "promscale.fullname" . }}
+      {{- if .Values.extraVolumes }}
+      {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "promscale.fullname" . }}
       automountServiceAccountToken: false
       {{- with .Values.nodeSelector }}

--- a/charts/promscale/values.yaml
+++ b/charts/promscale/values.yaml
@@ -32,6 +32,19 @@ extraEnv: []
 # Allows reference of secrets
 extraEnvFrom: []
 
+# Extra volumes to be able to add extra files to the configuration like the alertmanager and alerting rules configuration files or any other configuration require in a extra file
+# More info about volumes: https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumes: []
+#   - name: alertmanager
+#     configMap:
+#       name: alerting-configs
+
+extraVolumeMounts: []
+#   - name: alertmanager
+#     mountPath: "/etc/alertmanager/"
+#     readOnly: true
+
+
 # Annotations to be added to the promscale Deployment
 annotations: {}
 


### PR DESCRIPTION
Currently it is not possible using the helm chart to mount extra files to the deployment in order to configure extra functionalities like the alertmanager alerting rules according to:

https://docs.timescale.com/promscale/latest/alert/

In order to use the extra flag `-metrics.rules.config` is necessary to have the alertmanager files into the pod so the changes suggested here allows you to mount extra files from secrets or
configmaps according to the kubernetes options:

https://kubernetes.io/docs/concepts/storage/volumes/

I already performed some test locally configuring alerting rules and it works as expected, the Rule-Manager is started using the files mounted.

```
level=info ts=2022-09-14T10:24:49.657Z caller=runner.go:162 msg="Started Rule-Manager"
level=info ts=2022-09-14T10:24:49.657Z caller=runner.go:247 msg="Started OpenTelemetry OTLP GRPC server" listening-port=:9202
level=info ts=2022-09-14T10:24:49.657Z caller=rules.go:209 msg="Starting rule manager...
```

A values example of how to use the extraVolumes option:

```
extraVolumes:
  - name: alertmanager-config
    configMap:
      name: alertmanager-config

extraVolumeMounts:
  - name: alertmanager-config
    mountPath: "/etc/alertmanager/"
    readOnly: true
```

checking the pod files:

```
/ # ls -1 /etc/alertmanager/
alerting-rules.yaml
alertmanager-config.yaml
```

Signed-off-by: Kadaffy Talavera <kadaffy@ongres.com>

<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR allows users to mount extra volumes in order to be able to add extra configuration files like the ones used to configure alertmanager or any other extra file needed.

Allows you to mount files from secrets or configmaps according to the kubernetes options.


#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*


#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
