### PR TITLE
Add affinity schema to promscale chart

### DIFF
--- a/charts/promscale/Chart.yaml
+++ b/charts/promscale/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: promscale
 description: Promscale Connector deployment
 
-version: 14.1.1
+version: 14.1.2
 appVersion: 0.14.0
 
 home: https://github.com/timescale/promscale

--- a/charts/promscale/values.schema.json
+++ b/charts/promscale/values.schema.json
@@ -32,7 +32,80 @@
             "default": {},
             "title": "The affinity Schema",
             "required": [],
-            "properties": {},
+            "properties": {
+                "nodeAffinity": {
+                    "additionalProperties": false,
+                    "type": "object",
+                    "default": {},
+                    "title": "The nodeAffinity Schema",
+                    "required": [],
+                    "properties": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "additionalProperties": true,
+                            "type": "object",
+                            "default": {}
+                        },
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "additionalProperties": true,
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "podAffinity": {
+                    "additionalProperties": false,
+                    "type": "object",
+                    "default": {},
+                    "title": "The podAffinity Schema",
+                    "required": [],
+                    "properties": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "additionalProperties": true,
+                                "type": "object"
+                            }
+                        },
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "additionalProperties": true,
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "podAntiAffinity": {
+                    "additionalProperties": false,
+                    "type": "object",
+                    "default": {},
+                    "title": "The podAntiAffinity Schema",
+                    "required": [],
+                    "properties": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "additionalProperties": true,
+                                "type": "object"
+                            }
+                        },
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "additionalProperties": true,
+                                "type": "object"
+                            }
+                        }
+                    }
+                }
+            },
             "examples": [
                 {}
             ]


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Currently when we try to add affinities in the values.yaml file, it fails with a schema validation error. The schema for `affinity` is not correct and allows only empty object. This PR adds basic schema for this.


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
