### PR TITLE
.github: fix adding issues/prs to project board

### DIFF
--- a/.github/workflows/project-management.yml
+++ b/.github/workflows/project-management.yml
@@ -13,14 +13,13 @@ jobs:
   assign_issue:
     runs-on: ubuntu-latest
     name: Assign Issue to a Project
-    if: github.event_name == 'issues'
+    if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
     steps:
-    - name: Assign NEW issues to project O11y Applications
+    - name: Assign NEW issues/PRs to project O11y Applications
       uses: actions/add-to-project@main
       with:
         project-url: 'https://github.com/orgs/timescale/projects/54'
-        # PAT token is managed by @paulfantom
-        github-token: ${{ secrets.ORG_PROJECT_PAT }}
+        github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
 
   stale-issues-handler:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Seems like issues and PRs were flying-by us and not landing in Triage column. This PR should fix the broken link.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
