### PR TITLE
Added possibility to enable thanos StoreAPI port

### DIFF
--- a/charts/promscale/Chart.yaml
+++ b/charts/promscale/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: promscale
 description: Promscale Connector deployment
 
-version: 14.1.2
+version: 14.2.0
 appVersion: 0.14.0
 
 home: https://github.com/timescale/promscale

--- a/charts/promscale/templates/deployment-promscale.yaml
+++ b/charts/promscale/templates/deployment-promscale.yaml
@@ -68,6 +68,10 @@ spec:
               name: metrics-port
             - containerPort: 9202
               name: otel-port
+            {{- if .Values.service.thanosStoreAPI.enabled }}
+            - containerPort: {{ .Values.service.thanosStoreAPI.port }}
+              name: thanos-storeapi
+            {{- end }}
           readinessProbe:
           {{- toYaml .Values.readinessProbe | nindent 12 }}
           volumeMounts:

--- a/charts/promscale/templates/prometheus-rule.yaml
+++ b/charts/promscale/templates/prometheus-rule.yaml
@@ -272,6 +272,53 @@ spec:
         summary: Promscale maintenance jobs taking too long to complete.
         description: "Promscale Database is taking {{ $value }} seconds to respond to Promscale's requests."
         runbook_url: https://github.com/timescale/promscale/blob/master/docs/runbooks/PromscaleMaintenanceJobRunningTooLong.md
+    - alert: PromscaleMaintenanceJobNotKeepingup
+      expr: |
+        (
+            (
+              min_over_time(promscale_sql_database_chunks_metrics_uncompressed_count[1h]) > 10
+            )
+          and
+            (
+              delta(promscale_sql_database_chunks_metrics_uncompressed_count[10m]) > 0
+            )
+        )
+        or
+        (
+            (
+              min_over_time(promscale_sql_database_chunks_metrics_expired_count[1h]) > 10
+            )
+          and
+            (
+              delta(promscale_sql_database_chunks_metrics_expired_count[10m]) > 0
+            )
+        )      
+        or
+        (
+            (
+              min_over_time(promscale_sql_database_chunks_traces_uncompressed_count[1h]) > 10
+            )
+          and
+            (
+              delta(promscale_sql_database_chunks_traces_uncompressed_count[10m]) > 0
+            )
+        )      
+        or
+        (
+            (
+              min_over_time(promscale_sql_database_chunks_traces_expired_count[1h]) > 10
+            )
+          and
+            (
+              delta(promscale_sql_database_chunks_traces_expired_count[10m]) > 0
+            )
+        )      
+      labels:
+        severity: warning
+      annotations:
+        summary: Promscale maintenance jobs are not keeping up.
+        description: "The amount of work for the promscale maintenance {{ $labels.name }} job is not decreasing for long time."
+        runbook_url: https://github.com/timescale/promscale/blob/master/docs/runbooks/PromscaleMaintenanceJobRunningTooLong.md
     - alert: PromscaleMaintenanceJobFailures
       expr: promscale_sql_database_worker_maintenance_job_failed == 1
       labels:

--- a/charts/promscale/templates/svc-promscale.yaml
+++ b/charts/promscale/templates/svc-promscale.yaml
@@ -27,4 +27,10 @@ spec:
     targetPort: otel-port
     protocol: TCP
   {{- end }}
+  {{ if .Values.service.thanosStoreAPI.enabled }}
+  - name: thanos-storeapi
+    port: {{ .Values.service.thanosStoreAPI.port }}
+    targetPort: thanos-storeapi
+    protocol: TCP
+  {{- end }}
 {{- end }}

--- a/charts/promscale/values.yaml
+++ b/charts/promscale/values.yaml
@@ -111,6 +111,12 @@ service:
     enabled: true
     port: 9202
 
+  # Set port to enable Thanos StoreAPI
+  # Enable Thanos StoreAPI according to the configuration param "thanos.store-api.server-address" in https://github.com/timescale/promscale/blob/master/docs/configuration.md
+  thanosStoreAPI:
+    enabled: false
+    port: 9203
+
 # set your own limits
 resources: {}
 


### PR DESCRIPTION
Currently only ports 9201 and 9202 are enabled and it is not possible to enable a port with the helm chart to use the Thanos StoreAPI according to the configuration in
https://github.com/timescale/promscale/blob/master/docs/configuration.md using the param `thanos.store-api.server-address`.

I added the port configuration in the `values.yaml` and updated the deployment and service template, by default port will be set on false.

I already performed some test configuring the Thanos StoreAPI with:

```
config:
  thanos.store-api.server-address: ":9203"

service:
  thanosStoreAPI:
    enabled: true
    port: 9203
```

then checking the logs:

```
level=info ts=2022-09-19T16:22:29.822Z caller=runner.go:162 msg="Started Rule-Manager"
level=info ts=2022-09-19T16:22:29.822Z caller=runner.go:266 msg="Started Prometheus remote-storage HTTP server" listening-port=:9201
level=info ts=2022-09-19T16:22:29.822Z caller=rules.go:209 msg="Starting rule manager..."
level=info ts=2022-09-19T16:22:29.822Z caller=runner.go:247 msg="Started OpenTelemetry OTLP GRPC server" listening-port=:9202
level=info ts=2022-09-19T16:22:29.822Z caller=runner.go:204 msg="Started Thanos StoreAPI GRPC server" listening-port=:9203
```

Thanos StoreAPI is enabled and using the new configuration the service enabled the port to access the API.

service:
```
NAME               TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                      AGE
test-promscale     ClusterIP   10.96.15.61   <none>        9201/TCP,9202/TCP,9203/TCP   41s
```

Then [Thanos query](https://thanos.io/tip/components/query.md/) is able to connect to promscale.

Signed-off-by: Kadaffy Talavera <kadaffy@ongres.com>

<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Currently only ports 9201 and 9202 are enabled and it is not possible to enable a port using the helm chart to use the Thanos StoreAPI according to the configuration in
https://github.com/timescale/promscale/blob/master/docs/configuration.md using the param `thanos.store-api.server-address`.

This PR adds the possibility to enable a port to use the Thanos StoreAPI 

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*


#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
