### PR TITLE
Update avalanche helm chart to disable readinessProbe by default

### DIFF
--- a/charts/avalanche/Chart.yaml
+++ b/charts/avalanche/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: avalanche
 description: A Helm chart run avalanche for benchmarking Prometheus and remote write storage backends.
-version: 0.2.0
+version: 0.3.0
 
 home: https://github.com/timescale/helm-charts
 

--- a/charts/avalanche/templates/deployment-avalanche.yaml
+++ b/charts/avalanche/templates/deployment-avalanche.yaml
@@ -41,7 +41,11 @@ spec:
           ports:
           - containerPort: 9001
             name: metrics
+{{- if .Values.readinessProbe }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+{{- end }}
+{{- if .Values.resources }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+{{- end }}

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -62,24 +62,15 @@ serviceAccount:
 # set your own limits
 resources: {}
 
-# set a custom readiness probe e.g. when basic auth is enabled
-# readinessProbe:
-#   httpGet: null
-#   exec:
-#     command:
-#     - sh
-#     - -c
-#     - |-
-#       status_code=$(wget --server-response "http://${WEB_AUTH_USERNAME}:${WEB_AUTH_PASSWORD}@localhost:9001/health" 2>&1 | awk '/^  HTTP/{print $2}');
-#       if [[ "${status_code}" == "200" ]]; then exit 0; else exit 1; fi
 # NOTE: This readinessProbe will fail when remote_write is used, as avalanche
 # does not enable the healthcheck endpoint when remote write is used instead
 # of the /metrics endpoint.
-readinessProbe:
-  httpGet:
-    path: /health
-    port: metrics
-    scheme: HTTP
-  failureThreshold: 3
-  timeoutSeconds: 15
-  periodSeconds: 15
+# readinessProbe:
+#   httpGet:
+#     path: /health
+#     port: metrics
+#     scheme: HTTP
+#   failureThreshold: 3
+#   timeoutSeconds: 15
+#   periodSeconds: 15
+readinessProbe: {}


### PR DESCRIPTION
#### What this PR does / why we need it

Since we will mostly use avalanche with `--remote-url` flag, disabling the `readinessProbe` by default would be nice, since Avalanche will not expose the `/health` endpoint with it enabled.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
