### PR TITLE
Fix admin guide links in timescaledb-single readme

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.16.3
+version: 0.16.4
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/README.md
+++ b/charts/timescaledb-single/README.md
@@ -67,7 +67,7 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 helm install --name my-release -f myvalues.yaml charts/timescaledb-single
 ```
 
-For details about what parameters you can set, have a look at the [Administrator Guide](admin-guide.md#configure)
+For details about what parameters you can set, have a look at the [Administrator Guide](docs/admin-guide.md#configure)
 
 ### Installing from the Timescale Helm Repo
 
@@ -141,7 +141,7 @@ kubectl exec -ti $(kubectl get pod -o name -l role=master,release=$RELEASE) psql
 
 ## Create backups to S3
 The backup is disabled by default, look at the
-[Administrator Guide](admin-guide.md#backups) on how to configure backup location, credentials, schedules, etc.
+[Administrator Guide](docs/admin-guide.md#backups) on how to configure backup location, credentials, schedules, etc.
 
 ## Cleanup
 
@@ -150,9 +150,9 @@ To remove the spawned pods you can run a simple
 helm delete my-release
 ```
 Some items, (pvc's and S3 backups for example) are not immediately removed.
-To also purge these items, have a look at the [Administrator Guide](admin-guide.md#cleanup)
+To also purge these items, have a look at the [Administrator Guide](docs/admin-guide.md#cleanup)
 
 ## Further reading
 
-- [Administrator Guide](admin-guide.md)
+- [Administrator Guide](docs/admin-guide.md)
 - [TimescaleDB Documentation](https://docs.timescale.com/latest/main)


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

The links to the Admin Guide in the timescaledb-single readme file are incorrect. When clicked, a 404 is returned. 


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
