### PR TITLE
avalanche: Switch to StatefulSet for stable replica ID

### DIFF
--- a/charts/avalanche/Chart.yaml
+++ b/charts/avalanche/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: avalanche
 description: A Helm chart run avalanche for benchmarking Prometheus and remote write storage backends.
-version: 0.3.0
+version: 0.4.0
 
 home: https://github.com/timescale/helm-charts
 

--- a/charts/avalanche/templates/statefulset-avalanche.yaml
+++ b/charts/avalanche/templates/statefulset-avalanche.yaml
@@ -36,7 +36,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --port=9001
-            - --const-label=replica=$(POD_NAME)
             {{- with .Values.extraArgs -}}
             {{ tpl (toYaml . | nindent 12) $ }}
             {{- end }}

--- a/charts/avalanche/templates/statefulset-avalanche.yaml
+++ b/charts/avalanche/templates/statefulset-avalanche.yaml
@@ -2,7 +2,7 @@
 # Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "avalanche.fullname" . }}
   labels:
@@ -13,6 +13,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  serviceName: {{ template "avalanche.fullname" . }}
   selector:
     matchLabels:
       app: {{ template "avalanche.fullname" . }}
@@ -35,12 +36,18 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --port=9001
+            - --const-label=replica=$(POD_NAME)
             {{- with .Values.extraArgs -}}
             {{ tpl (toYaml . | nindent 12) $ }}
             {{- end }}
           ports:
           - containerPort: 9001
             name: metrics
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
 {{- if .Values.readinessProbe }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -31,7 +31,8 @@ replicaCount: 1
 #   - --remote-tenant="0"                             Tenant ID to include in remote_write send
 #   - --tls-client-insecure                           Skip certificate check on tls connection
 #   - --remote-tenant-header="X-Scope-OrgID"          Tenant ID to include in remote_write send. The default, is the default tenant header expected by Cortex.
-extraArgs: []
+extraArgs:
+  - --const-label=avalanche_replica=$(POD_NAME)
 
 # Annotations to be added to the avalanche Deployment
 annotations: {}

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -52,7 +52,9 @@ service:
   annotations: {}
   port: 9001
   # properties to be added to service.spec
-  spec: {}
+  spec:
+    # Headless service is required for stable network IDs of statefulset pods.
+    clusterIP: None
 
 # create and attach a service account
 serviceAccount:


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR moves avalanche deployment mode to StatefulSet. This will give stable IDs to pods which can be used as replica label.



#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
