### PR TITLE
feat(timescaledb-single): Allow setting resources for pgbackrest container

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.17.0
+version: 0.18.0
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/docs/admin-guide.md
+++ b/charts/timescaledb-single/docs/admin-guide.md
@@ -28,6 +28,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `backup.pgBackRest:archive-get`   | [pgBackRest global:archive-get configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)  | empty |
 | `backup.pgBackRest:archive-push`  | [pgBackRest global:archive-push configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza) | empty |
 | `backup.pgBackRest`               | [pgBackRest global configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)              | Working defaults, using `lz4` compression |
+| `backup.resources`                | Any resources you wish to assign to the pgbackrest container                                                       | `{}` |
 | `callbacks.configMap`             | A kubernetes ConfigMap containing [Patroni callbacks](#callbacks). You can use templates in the name. | `nil`                         |
 | `clusterName`                     | Override the name of the PostgreSQL cluster | Equal to the Helm release name                      |
 | `env`                             | Extra custom environment variables, expressed as [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvarsource-v1-core)   | `[]`                                                |
@@ -90,7 +91,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `replicaLoadBalancer.annotations` | Deprecated(0.10.0): Pass on annotations to the Load Balancer | An AWS ELB annotation to increase the idle timeout |
 | `replicaLoadBalancer.enabled` | Deprecated(0.10.0): If enabled, creates a LB for replica's only  | `false` |
 | `replicaLoadBalancer.spec`    | Deprecated(0.10.0): Extra configuration for replica service spec | `nil`   |
-| `resources`                       | Any resources you wish to assign to the pod | `{}`                                                |
+| `resources`                       | Any resources you wish to assign to the timescaledb container | `{}`   |
 | `schedulerName`                   | Alternate scheduler name                    | `nil`                                               |
 | `secrets.credentials`             | A map of environment variables that influence Patroni, for example PATRONI_SUPERUSER_PASSWORD or PATRONI_REPLICATION_PASSWORD | Randomly generated |
 | `secrets.credentialsSecretName`   | Existing secret that contains env vars that influence Patroni (e.g. PATRONI_SUPERUSER_PASSWORD). This setting takes precedence over everything set in `secrets.credentials` | `""` |

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -381,6 +381,8 @@ spec:
         ports:
         - containerPort: 8081
           name: pgbackrest
+        resources:
+{{ toYaml .Values.backup.resources | indent 10 }}
         volumeMounts:
         - name: socket-directory
           mountPath: {{ template "socket_directory" . }}

--- a/charts/timescaledb-single/values.schema.json
+++ b/charts/timescaledb-single/values.schema.json
@@ -169,6 +169,12 @@
             "object",
             "null"
           ]
+        },
+        "resources": {
+          "type": [
+            "object",
+            "null"
+          ]
         }
       },
       "required": [

--- a/charts/timescaledb-single/values.schema.yaml
+++ b/charts/timescaledb-single/values.schema.yaml
@@ -490,6 +490,10 @@ properties:
         type:
           - array
           - "null"
+      resources:
+        type:
+          - object
+          - "null"
   secrets:
     type: object
     additionalProperties: false

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -111,6 +111,15 @@ backup:
   #     secretKeyRef:
   #       name: pgbackrest-dev-secrets
   #       key: repo1-s3-key-secret
+  resources: {}
+  # If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
 # When creating a *new* deployment, the default is to initialize (using initdb) the database.
 # If however, you want to initialize the database using an existing backup, you can do so by


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR adds support for setting resources on the `pgbackrest` container.

#### Which issue this PR fixes

- fixes #264

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
