### PR TITLE
Fix regexp in renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,7 @@
         "depNameTemplate": "golang"
       },
       {
-        "fileMatch": ["^\\charts\\/promscale\\/Chart\\.yaml$"],
+        "fileMatch": ["^charts\\/promscale\\/Chart\\.ya?ml$"],
         "matchStrings": ["appVersion:\\s(?<currentValue>.*?)\\n"],
         "datasourceTemplate": "github-tags",
         "depNameTemplate": "timescale/promscale"


### PR DESCRIPTION
#### What this PR does / why we need it

Regular expression was not validating for the renovate configuration


#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #474 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
