### PR TITLE
Adding in helm chart to be used with tracing benchmark

### DIFF
--- a/charts/tracing-es-jaeger/Chart.yaml
+++ b/charts/tracing-es-jaeger/Chart.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v2
+name: tracing-es-jaeger
+description: A Helm chart for tracing-es-jaeger, benchmarking scenario
+home: https://github.com/timescale/helm-charts
+sources:
+  - https://github.com/timescale/helm-charts
+maintainers:
+  - name: timescale
+    url: https://www.timescale.com/
+keywords:
+  - observability
+  - monitoring
+  - tracing
+  - opentelemetry
+  - benchmarking
+version: 0.0.1

--- a/charts/tracing-es-jaeger/default-tracegen-config.json
+++ b/charts/tracing-es-jaeger/default-tracegen-config.json
@@ -1,0 +1,620 @@
+{
+  "topology": {
+    "services": [
+      {
+        "serviceName": "frontend",
+        "tagSets": [
+          {
+            "weight": 1,
+            "tags": {
+              "version": "v127",
+              "region": "us-east-1"
+            },
+            "tagGenerators": [],
+            "inherit": [],
+            "maxLatency": 100
+          },
+          {
+            "weight": 1,
+            "tags": {
+              "version": "v125",
+              "region": "us-east-1"
+            },
+            "tagGenerators": [],
+            "inherit": [],
+            "maxLatency": 100
+          },
+          {
+            "weight": 2,
+            "tags": {
+              "version": "v125",
+              "region": "us-west-1"
+            },
+            "tagGenerators": [],
+            "inherit": [],
+            "maxLatency": 100
+          }
+        ],
+        "routes": [
+          {
+            "route": "/product",
+            "downstreamCalls": {
+              "productcatalogservice": "/GetProducts",
+              "recommendationservice": "/GetRecommendations",
+              "adservice": "/AdRequest"
+            },
+            "tagSets": [
+              {
+                "weight": 1,
+                "tags": {
+                  "starter": "charmander"
+                },
+                "tagGenerators": [],
+                "inherit": []
+              },
+              {
+                "weight": 1,
+                "tags": {
+                  "starter": "squirtle"
+                },
+                "tagGenerators": [],
+                "inherit": []
+              },
+              {
+                "weight": 1,
+                "tags": {
+                  "starter": "bulbasaur"
+                },
+                "tagGenerators": [],
+                "inherit": []
+              }
+            ]
+          },
+          {
+            "route": "/cart",
+            "downstreamCalls": {
+              "cartservice": "/GetCart",
+              "recommendationservice": "/GetRecommendations",
+              "shippingservice": "/GetQuote",
+              "checkoutservice": "/PlaceOrder"
+            },
+            "tagSets": []
+          },
+          {
+            "route": "/checkout",
+            "downstreamCalls": {
+              "checkoutservice": "/PlaceOrder"
+            },
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 800
+              }
+            ]
+          },
+          {
+            "route": "/shipping",
+            "downstreamCalls": {
+              "shippingservice": "/GetQuote"
+            },
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 50
+              }
+            ]
+          },
+          {
+            "route": "/currency",
+            "downstreamCalls": {
+              "currencyservice": "/GetConversion"
+            },
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 50
+              }
+            ]
+          }
+        ],
+        "instances": [
+          "frontend-6b654dbf57-zq8dt",
+          "frontend-d847fdcf5-j6s2f",
+          "frontend-79d8c8d6c8-9sbff"
+        ],
+        "mergedTagSets": {},
+        "random": {
+          "seed": 187004238864083,
+          "nextNextGaussian": 0,
+          "haveNextNextGaussian": false
+        }
+      },
+      {
+        "serviceName": "productcatalogservice",
+        "tagSets": [
+          {
+            "tags": {
+              "version": "v52"
+            },
+            "tagGenerators": [],
+            "inherit": [
+              "region"
+            ]
+          }
+        ],
+        "routes": [
+          {
+            "route": "/GetProducts",
+            "downstreamCalls": {},
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [
+                  "starter"
+                ],
+                "maxLatency": 100
+              }
+            ]
+          },
+          {
+            "route": "/SearchProducts",
+            "downstreamCalls": {},
+            "tagSets": [
+              {
+                "weight": 15,
+                "tags": {
+                  "error": true,
+                  "http.status_code": 503
+                },
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 400
+              },
+              {
+                "weight": 85,
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 400
+              }
+            ]
+          }
+        ],
+        "instances": [
+          "productcatalogservice-6b654dbf57-zq8dt",
+          "productcatalogservice-d847fdcf5-j6s2f"
+        ],
+        "mergedTagSets": {},
+        "random": {
+          "seed": 238238032670139,
+          "nextNextGaussian": 0,
+          "haveNextNextGaussian": false
+        }
+      },
+      {
+        "serviceName": "recommendationservice",
+        "tagSets": [
+          {
+            "tags": {
+              "version": "v234",
+              "region": "us-east-1"
+            },
+            "tagGenerators": [],
+            "inherit": []
+          }
+        ],
+        "routes": [
+          {
+            "route": "/GetRecommendations",
+            "downstreamCalls": {
+              "productcatalogservice": "/GetProducts"
+            },
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 200
+              }
+            ]
+          }
+        ],
+        "instances": [
+          "recommendationservice-6b654dbf57-zq8dt",
+          "recommendationservice-d847fdcf5-j6s2f"
+        ],
+        "mergedTagSets": {},
+        "random": {
+          "seed": 66295214032801,
+          "nextNextGaussian": 0,
+          "haveNextNextGaussian": false
+        }
+      },
+      {
+        "serviceName": "cartservice",
+        "tagSets": [
+          {
+            "tags": {
+              "version": "v5",
+              "region": "us-east-1"
+            },
+            "tagGenerators": [],
+            "inherit": []
+          }
+        ],
+        "routes": [
+          {
+            "route": "/GetCart",
+            "downstreamCalls": {},
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 200
+              }
+            ]
+          }
+        ],
+        "instances": [
+          "cartservice-6b654dbf57-zq8dt",
+          "cartservice-d847fdcf5-j6s2f"
+        ],
+        "mergedTagSets": {},
+        "random": {
+          "seed": 234194353561392,
+          "nextNextGaussian": 0,
+          "haveNextNextGaussian": false
+        }
+      },
+      {
+        "serviceName": "checkoutservice",
+        "tagSets": [
+          {
+            "tags": {
+              "version": "v37",
+              "region": "us-east-1"
+            },
+            "tagGenerators": [],
+            "inherit": [],
+            "maxLatency": 500
+          }
+        ],
+        "routes": [
+          {
+            "route": "/PlaceOrder",
+            "downstreamCalls": {
+              "paymentservice": "/CreditCardInfo",
+              "shippingservice": "/Address",
+              "currencyservice": "/GetConversion",
+              "cartservice": "/GetCart",
+              "emailservice": "/SendOrderConfirmation"
+            },
+            "tagSets": [
+              {
+                "weight": 25,
+                "tags": {
+                  "error": true,
+                  "http.status_code": 503
+                },
+                "tagGenerators": [],
+                "inherit": []
+              },
+              {
+                "weight": 85,
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": []
+              }
+            ]
+          }
+        ],
+        "instances": [
+          "checkoutservice-6b654dbf57-zq8dt",
+          "checkoutservice-d847fdcf5-j6s2f"
+        ],
+        "mergedTagSets": {},
+        "random": {
+          "seed": 60782549660568,
+          "nextNextGaussian": 0,
+          "haveNextNextGaussian": false
+        }
+      },
+      {
+        "serviceName": "paymentservice",
+        "tagSets": [
+          {
+            "tags": {
+              "version": "v177",
+              "region": "us-east-1"
+            },
+            "tagGenerators": [],
+            "inherit": []
+          }
+        ],
+        "routes": [
+          {
+            "route": "/ChargeRequest",
+            "downstreamCalls": {
+              "paymentservice": "/CreditCardInfo"
+            },
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 700
+              }
+            ]
+          },
+          {
+            "route": "/CreditCardInfo",
+            "downstreamCalls": {},
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 50
+              }
+            ]
+          }
+        ],
+        "instances": [
+          "paymentservice-6b654dbf57-zq8dt",
+          "paymentservice-d847fdcf5-j6s2f"
+        ],
+        "mergedTagSets": {},
+        "random": {
+          "seed": 174850031049111,
+          "nextNextGaussian": 0,
+          "haveNextNextGaussian": false
+        }
+      },
+      {
+        "serviceName": "shippingservice",
+        "tagSets": [
+          {
+            "tags": {
+              "version": "v127",
+              "region": "us-east-1"
+            },
+            "tagGenerators": [],
+            "inherit": []
+          }
+        ],
+        "routes": [
+          {
+            "route": "/GetQuote",
+            "downstreamCalls": {
+              "shippingservice": "/Address"
+            },
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 250
+              }
+            ]
+          },
+          {
+            "route": "/ShipOrder",
+            "downstreamCalls": {
+              "shippingservice": "/Address"
+            },
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 500
+              }
+            ]
+          },
+          {
+            "route": "/Address",
+            "downstreamCalls": {},
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 100
+              }
+            ]
+          }
+        ],
+        "instances": [
+          "shippingservice-6b654dbf57-zq8dt",
+          "shippingservice-d847fdcf5-j6s2f"
+        ],
+        "mergedTagSets": {},
+        "random": {
+          "seed": 107892261530518,
+          "nextNextGaussian": 0,
+          "haveNextNextGaussian": false
+        }
+      },
+      {
+        "serviceName": "emailservice",
+        "tagSets": [
+          {
+            "tags": {
+              "version": "v27",
+              "region": "us-east-1"
+            },
+            "tagGenerators": [],
+            "inherit": [],
+            "maxLatency": 500
+          }
+        ],
+        "routes": [
+          {
+            "route": "/SendOrderConfirmation",
+            "downstreamCalls": {
+              "emailservice": "/OrderResult"
+            },
+            "tagSets": [
+              {
+                "weight": 15,
+                "tags": {
+                  "error": true,
+                  "http.status_code": 503
+                },
+                "tagGenerators": [],
+                "inherit": []
+              },
+              {
+                "weight": 85,
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": []
+              }
+            ]
+          },
+          {
+            "route": "/OrderResult",
+            "downstreamCalls": {},
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 100
+              }
+            ]
+          }
+        ],
+        "instances": [
+          "emailservice-6b654dbf57-zq8dt",
+          "emailservice-d847fdcf5-j6s2f"
+        ],
+        "mergedTagSets": {},
+        "random": {
+          "seed": 61175057559946,
+          "nextNextGaussian": 0,
+          "haveNextNextGaussian": false
+        }
+      },
+      {
+        "serviceName": "currencyservice",
+        "tagSets": [
+          {
+            "tags": {
+              "version": "v27",
+              "region": "us-east-1"
+            },
+            "tagGenerators": [],
+            "inherit": []
+          }
+        ],
+        "routes": [
+          {
+            "route": "/GetConversion",
+            "downstreamCalls": {
+              "currencyservice": "/Money"
+            },
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 100
+              }
+            ]
+          },
+          {
+            "route": "/Money",
+            "downstreamCalls": {},
+            "tagSets": [
+              {
+                "tags": {},
+                "tagGenerators": [],
+                "inherit": [],
+                "maxLatency": 100
+              }
+            ]
+          }
+        ],
+        "instances": [
+          "currencyservice-6b654dbf57-zq8dt",
+          "currencyservice-d847fdcf5-j6s2f"
+        ],
+        "mergedTagSets": {},
+        "random": {
+          "seed": 66219471499700,
+          "nextNextGaussian": 0,
+          "haveNextNextGaussian": false
+        }
+      },
+      {
+        "serviceName": "adservice",
+        "tagSets": [
+          {
+            "tags": {},
+            "tagGenerators": [],
+            "inherit": [],
+            "maxLatency": 500
+          }
+        ],
+        "routes": [
+          {
+            "route": "/AdRequest",
+            "downstreamCalls": {},
+            "tagSets": []
+          },
+          {
+            "route": "/Ad",
+            "downstreamCalls": {},
+            "tagSets": []
+          }
+        ],
+        "instances": [
+          "adservice-6b654dbf57-zq8dt",
+          "adservice-d847fdcf5-j6s2f"
+        ],
+        "mergedTagSets": {},
+        "random": {
+          "seed": 22694143111805,
+          "nextNextGaussian": 0,
+          "haveNextNextGaussian": false
+        }
+      }
+    ]
+  },
+  "rootRoutes": [
+    {
+      "service": "frontend",
+      "route": "/product",
+      "tracesPerHour": 900000
+    },
+    {
+      "service": "frontend",
+      "route": "/cart",
+      "tracesPerHour": 900000
+    },
+    {
+      "service": "frontend",
+      "route": "/shipping",
+      "tracesPerHour": 900000
+    },
+    {
+      "service": "frontend",
+      "route": "/currency",
+      "tracesPerHour": 900000
+    },
+    {
+      "service": "frontend",
+      "route": "/checkout",
+      "tracesPerHour": 900000
+    }
+  ]
+}

--- a/charts/tracing-es-jaeger/templates/elasticsearch.yaml
+++ b/charts/tracing-es-jaeger/templates/elasticsearch.yaml
@@ -1,0 +1,47 @@
+---
+{{ if .Values.elasticsearch.enabled }}
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch-sample
+  namespace: {{ .Release.Namespace }}
+spec:
+  version: {{ .Values.elasticsearch.version }}
+  auth:
+    fileRealm:
+    - secretName: es-bench-user
+  nodeSets:
+  - name: default
+    config:
+      node.roles: ["master", "data", "ingest", "ml"]
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            requests: 
+              memory: {{ .Values.elasticsearch.resources.requests.memory }}
+              cpu: {{ .Values.elasticsearch.resources.requests.cpu }}
+            limits:
+              memory: {{ .Values.elasticsearch.resources.limits.memory }}
+              cpu: {{ .Values.elasticsearch.resources.limits.cpu }}
+          env:
+          {{- if .Values.elasticsearch.env }}
+            {{- range $.Values.elasticsearch.env }}
+            - name: {{ .name }}
+              value: {{ tpl (.value | quote) $ }}
+            {{- end }}
+          {{- end }}
+
+    count: 3
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data # Do not change this name unless you set up a volume mount for the data path.
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.elasticsearch.volumes.resources.requests.storage }}
+{{- end }}

--- a/charts/tracing-es-jaeger/templates/es-secret.yaml
+++ b/charts/tracing-es-jaeger/templates/es-secret.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.elasticsearch.enabled }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: es-bench-user
+  namespace: {{ .Release.Namespace }}
+stringData:
+  users: |-
+    admin:$2a$04$au47bjkglcN0NcYV5.qIeeWFwxNVQ3ennnfF3Wsd/NWaNCWGTlr6m
+  users_roles: |-
+    superuser:admin
+{{ end }}

--- a/charts/tracing-es-jaeger/templates/jaeger.yaml
+++ b/charts/tracing-es-jaeger/templates/jaeger.yaml
@@ -1,0 +1,44 @@
+---
+{{ if .Values.jaeger.enabled }}
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: simple-prod
+  namespace: {{ .Release.Namespace }}
+spec:
+  strategy: production
+  query:
+    replicas: {{ .Values.jaeger.query.replicas }}
+    serviceType: {{ .Values.jaeger.query.serviceType }} 
+    resources:
+      requests:
+        cpu: {{ .Values.jaeger.query.resources.requests.cpu }}
+        memory: {{ .Values.jaeger.query.resources.requests.memory }}
+  collector:
+    replicas: {{ .Values.jaeger.collector.replicas }}
+    autoscale: {{ .Values.jaeger.collector.autoscale }}
+    resources:
+      requests:
+        cpu: {{ .Values.jaeger.collector.resources.requests.cpu }}
+        memory: {{ .Values.jaeger.collector.resources.requests.memory }}
+    options:
+      collector:
+        queue-size: {{ .Values.jaeger.collector.options.collector.queueSize }}
+        num-workers: {{ .Values.jaeger.collector.options.collector.numWorkers }}
+  storage:
+    type: elasticsearch
+    options:
+      es:
+        server-urls: https://elasticsearch-sample-es-http:9200
+        tls.skip-host-verify: true
+        username: admin
+        password: admin
+  volumeMounts:
+    - name: secrets
+      mountPath: /es/secrets/
+      readOnly: true
+  volumes:
+    - name: secrets
+      secret:
+        secretName: elasticsearch-sample-es-http-certs-public
+{{- end }}

--- a/charts/tracing-es-jaeger/templates/load-generator-deployment.yaml
+++ b/charts/tracing-es-jaeger/templates/load-generator-deployment.yaml
@@ -1,0 +1,43 @@
+---
+{{ if .Values.tracegen.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synthetic-load-gen
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: synthetic-load-gen
+  template:
+    metadata:
+      labels:
+        app: synthetic-load-gen
+    spec:
+      containers:
+      - name: synthetic-load-gen
+        image: omnition/synthetic-load-generator:1.0.25
+        resources:
+          requests:
+            cpu: {{ .Values.tracegen.resources.requests.cpu }}
+            memory: {{ .Values.tracegen.resources.requests.memory }}
+          limits:
+            cpu: {{ .Values.tracegen.resources.limits.cpu }}
+            memory: {{ .Values.tracegen.resources.limits.memory }}
+        volumeMounts:
+        - name: topology-volume
+          mountPath: /etc/synthetic-load-generator
+        env:
+          - name: TOPOLOGY_FILE
+            value: /etc/synthetic-load-generator/topology.json
+          - name: JAEGER_COLLECTOR_URL
+            value: http://simple-prod-collector.{{ .Release.Namespace }}.svc.cluster.local:14268
+      volumes:
+        - name: topology-volume
+          configMap:
+            name: topology
+            items:
+            - key: topology
+              path: topology.json
+{{- end }}

--- a/charts/tracing-es-jaeger/templates/load-generator-service.yaml
+++ b/charts/tracing-es-jaeger/templates/load-generator-service.yaml
@@ -1,0 +1,11 @@
+---
+{{ if .Values.tracegen.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: topology
+  namespace: {{ .Release.Namespace }}
+data: 
+  topology: |
+{{ .Values.tracegen.config | default (.Files.Get "default-tracegen-config.json" | indent 4) }}
+{{- end }}

--- a/charts/tracing-es-jaeger/values.yaml
+++ b/charts/tracing-es-jaeger/values.yaml
@@ -1,0 +1,49 @@
+---
+elasticsearch:
+  enabled: true
+  version: 7.17.0
+  resources:
+    requests:
+      memory: 25Gi
+      cpu: 10
+    limits:
+      memory: 30Gi
+      cpu: 15
+  env:
+    - name: ES_JAVA_OPTS
+      value: "-Xms25g -Xmx25g"
+  volumes:
+    resources:
+      requests:
+        storage: 1100Gi
+
+jaeger:
+  enabled: true
+  query:
+    replicas: 1
+    serviceType: ClusterIP
+    resources:
+      requests:
+        cpu: 4000m
+        memory: 2Gi
+  collector:
+    replicas: 4
+    autoscale: false
+    resources:
+      requests:
+        cpu: 4000m
+        memory: 2Gi
+    options:
+      collector:
+        queueSize: 100000
+        numWorkers: 1000
+
+tracegen:
+  enabled: true
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 2Gi


### PR DESCRIPTION
#### What this PR does / why we need it

This helm chart is to be used with a tracing benchmarking scenario for Elasticsearch and Jaeger.  Tracegen is used for synthetic load generator.

It will use this Helm chart: https://github.com/timescale/promscale-benchmark/pull/18

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes https://github.com/timescale/promscale-benchmark/issues/5

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
