### PR TITLE
fix targetLabels field for pod monitor

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.21.0
+version: 0.22.0
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/docs/admin-guide.md
+++ b/charts/timescaledb-single/docs/admin-guide.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `podMonitor.namespace`        | Setting this will cause deploying podMonitor in a different namespace than TimescaleDB. | `nil` |
 | `podMonitor.labels`           | Additional labels that can be set on podMonitor object. | `nil` |
 | `podMonitor.metricRelabelings` | Additional prometheus metric relabelings. | `nil` |
-| `podMonitor.targetLabels`     | List of additional kubernetes labels that need to be transferred from Service object into metrics. | `nil` |
+| `podMonitor.podTargetLabels`  | List of additional kubernetes labels that need to be transferred from Pod object into metrics. | `nil` |
 | `prometheus.enabled`              | If enabled, run a [postgres\_exporter](https://github.com/prometheus-community/postgres_exporter) sidecar | `false` |
 | `prometheus.image.pullPolicy`     | The pull policy for the postgres\_exporter  | `IfNotPresent`                                      |
 | `prometheus.image.repository`     | The postgres\_exporter docker repo          | `quay.io/prometheuscommunity/postgres_exporter`     |

--- a/charts/timescaledb-single/templates/podmonitor.yaml
+++ b/charts/timescaledb-single/templates/podmonitor.yaml
@@ -29,8 +29,8 @@ spec:
     matchLabels:
       app: {{ template "timescaledb.fullname" . }}
       release: "{{ .Release.Name }}"
-  {{- if .Values.podMonitor.targetLabels }}
-  targetLabels: {{ toYaml .Values.podMonitor.targetLabels | nindent 4 }}
+  {{- if .Values.podMonitor.podTargetLabels }}
+  podTargetLabels: {{ toYaml .Values.podMonitor.podTargetLabels | nindent 4 }}
   {{- end }}
   namespaceSelector:
     matchNames:

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -533,7 +533,7 @@ podMonitor:
   #   release: prometheus
   # honorLabels: true
   # metricRelabelings: []
-  # targetLabels:
+  # podTargetLabels:
   #   - foo
 
 # For new deployments, we would advise Parallel here, however as that change breaks previous


### PR DESCRIPTION
The field for target labels in a PodMonitor spec is called [podTargetLabels](https://github.com/prometheus-operator/prometheus-operator/blob/main/pkg/apis/monitoring/v1/types.go\#L1330). The `targetLabels` field only exists for service monitors.

<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

The `targetLabels` field does not exist for pod monitors, but only for service monitors. To transfer labels when using a pod monitor, the field `podTargetLabels` should be used.

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
