### PR TITLE
bump timescaledb-ha image to the latest version

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.22.0
+version: 0.23.0
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -20,7 +20,7 @@ image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescale/timescaledb-ha
-  tag: pg14.5-ts2.8.1-p1
+  tag: pg14.6-ts2.8.1-p0
   pullPolicy: Always
 
 # By default those secrets are randomly generated.


### PR DESCRIPTION
#### What this PR does / why we need it

Bump `timescaledb-ha` image to the latest version. 

This adds a fix for the Patroni Kubernetes 403 issue:  https://github.com/zalando/patroni/issues/1132

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes:
 * https://github.com/zalando/patroni/issues/1132
 * https://github.com/zalando/patroni/pull/2390
 * https://github.com/timescale/tobs/issues/646
 * https://github.com/timescale/helm-charts/issues/418
 * https://github.com/timescale/helm-charts/pull/398
 * https://github.com/timescale/helm-charts/issues/405

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
