### PR TITLE
avalanche: Add headless service required for the statefulset

### DIFF
--- a/charts/avalanche/Chart.yaml
+++ b/charts/avalanche/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: avalanche
 description: A Helm chart run avalanche for benchmarking Prometheus and remote write storage backends.
-version: 0.7.0
+version: 0.8.0
 
 home: https://github.com/timescale/helm-charts
 

--- a/charts/avalanche/templates/service-monitor.yaml
+++ b/charts/avalanche/templates/service-monitor.yaml
@@ -12,5 +12,6 @@ spec:
     path: /metrics
   selector:
     matchLabels:
+      prometheus-scrape-enabled: "true"
 {{ include "avalanche.labels" . | indent 6 }}
 {{- end }}

--- a/charts/avalanche/templates/service-monitor.yaml
+++ b/charts/avalanche/templates/service-monitor.yaml
@@ -10,6 +10,10 @@ spec:
   - interval: 30s
     port: metrics
     path: /metrics
+    metricRelabelings:
+      sourceLabels: ['namespace', 'job']
+      separator: "/"
+      targetLabel: 'instance'
   selector:
     matchLabels:
       prometheus-scrape-enabled: "true"

--- a/charts/avalanche/templates/svc-avalanche.yaml
+++ b/charts/avalanche/templates/svc-avalanche.yaml
@@ -7,24 +7,25 @@ metadata:
   labels:
 {{ include "avalanche-helm.labels" . | indent 4 }}
     app.kubernetes.io/component: avalanche
-{{- if .Values.service.labels }}
-{{ .Values.service.labels | toYaml | indent 4 }}
+    prometheus-scrape-enabled: "true"
+{{- if .Values.service.scrape.labels }}
+{{ .Values.service.scrape.labels | toYaml | indent 4 }}
 {{- end }}
-{{- if .Values.service.annotations }}
+{{- if .Values.service.scrape.annotations }}
   annotations:
-{{ .Values.service.annotations | toYaml | indent 4 }}
+{{ .Values.service.scrape.annotations | toYaml | indent 4 }}
 {{- end }}
 spec:
   selector:
 {{ include "avalanche.labels" . | indent 4}}
-  type: {{ .Values.service.type }}
+  type: {{ .Values.service.scrape.type }}
   ports:
   - name: metrics
-    port: {{ .Values.service.port }}
+    port: {{ .Values.service.scrape.port }}
     targetPort: metrics
     protocol: TCP
-{{- if .Values.service.spec }}
-{{ .Values.service.spec | toYaml | indent 2 }}
+{{- if .Values.service.scrape.spec }}
+{{ .Values.service.scrape.spec | toYaml | indent 2 }}
 {{- end }}
 {{- end }}
 ---

--- a/charts/avalanche/templates/svc-headless.yaml
+++ b/charts/avalanche/templates/svc-headless.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "avalanche.fullname" . }}
+  labels:
+{{ include "avalanche-helm.labels" . | indent 4 }}
+    app.kubernetes.io/component: avalanche
+{{- if .Values.service.primary.labels }}
+{{ .Values.service.primary.labels | toYaml | indent 4 }}
+{{- end }}
+{{- if .Values.service.primary.annotations }}
+  annotations:
+{{ .Values.service.primary.annotations | toYaml | indent 4 }}
+{{- end }}
+spec:
+  selector:
+{{ include "avalanche.labels" . | indent 4}}
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: {{ .Values.service.primary.port }}
+    targetPort: metrics
+    protocol: TCP
+{{- if .Values.service.primary.spec }}
+{{ .Values.service.primary.spec | toYaml | indent 2 }}
+{{- end }}

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -52,21 +52,32 @@ labels: {}
 serviceMonitor:
   enabled: false
 
-# Number of fake ServiceMonitor to be created to simulate fake Prometheus
+# Number of Service objects to be created to simulate fake Prometheus
 # targets. This will be useful to generate more series without scaling
 # Avalanche pods when using it as a Prometheus target.
+# To configure these services, take a look at `service.scrape`.
 fakePrometheusTargetCount: 1
 
-# settings for the service to be created that will expose
-# the avalanche deployment
+# Settings for the services to be created that will expose
+# the avalanche deployment.
 service:
-  type: "ClusterIP"
-  annotations: {}
-  port: 9001
-  # properties to be added to service.spec
-  spec:
-    # Headless service is required for stable network IDs of statefulset pods.
-    clusterIP: None
+  # Configures the primary headless service, required for stable network IDs
+  # of statefulset pods.
+  primary:
+    port: 9001
+    labels: {}
+    annotations: {}
+    # properties to be added to service.spec
+    spec: {}
+  # Configures the services that are scraped by ServiceMonitor. The number of these
+  # services will be equal to fakePrometheusTargetCount.
+  scrape:
+    type: "ClusterIP"
+    port: 9001
+    labels: {}
+    annotations: {}
+    # properties to be added to service.spec
+    spec: {}
 
 # create and attach a service account
 serviceAccount:


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR adds back the headless service for avalanche as we are using StatefulSet for deploying the pods. It also adds an additional label to the scrape services, so that only those will get picked up by the ServiceMonitor.


#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

The changes in the values.yaml are breaking changes, but we are at `0.x.x` releases so semantically it is okay I guess. I went with breaking changes in favour of cleaner values.yaml, but if needed we can make this change non-breaking as well.


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
