### PR TITLE
Add helm chart for parca-agent

### DIFF
--- a/charts/parca-agent/Chart.yaml
+++ b/charts/parca-agent/Chart.yaml
@@ -1,0 +1,27 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+apiVersion: v2
+name: parca-agent
+description: Parca Agent deployment.
+
+version: 0.1.0
+appVersion: v0.10.0-rc.1
+
+home: https://github.com/timescale/helm-charts
+
+sources:
+  - https://github.com/timescale/helm-charts
+  - https://github.com/parca-dev/parca-agent
+
+maintainers:
+  - name: timescale
+    url: https://www.timescale.com/
+
+keywords:
+  - continuous-profiling
+  - performance
+  - profiling
+  - monitoring
+  - prometheus
+  - ebpf

--- a/charts/parca-agent/README.md
+++ b/charts/parca-agent/README.md
@@ -1,0 +1,54 @@
+<!---
+This file and its contents are licensed under the Apache License 2.0.
+Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+-->
+
+# Parca Server
+
+##### Table of Contents
+- [Introduction](#introduction)
+- [Installation](#installation)
+  - [Installing from the Timescale Helm Repo](#installing-from-the-timescale-helm-repo)
+
+## Introduction
+This directory contains a Helm chart to deploy [Parca Agent](https://github.com/parca-dev/parca-agent),
+used for Open Source infrastructure-wide continous profiling.
+
+## Installation
+
+To install the chart with the release name `my-release`, you can clone the git repo and run the command:
+```console
+helm install --name my-release ./charts/parca-agent
+```
+
+You can override parameters using the `--set key=value[,key=value]` argument to `helm install`,
+e.g., to disable service account creation:
+
+```console
+helm install --name my-release ./charts/parca-agent --set serviceAccount.create=false
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+```console
+helm install --name my-release -f myvalues.yaml ./charts/parca-agent
+```
+
+### Installing from the Timescale Helm Repo
+
+We have a Helm Repository that you can use, instead of cloning this Git repo. 
+
+First add the repository with:
+```console
+helm repo add timescale 'https://charts.timescale.com'
+```
+
+Next proceed to install the chart:
+
+```console
+helm install my-release timescale/parca-agent
+```
+
+To keep the repo up to date with new versions you can do:
+```console
+helm repo update
+```

--- a/charts/parca-agent/templates/_helpers.tpl
+++ b/charts/parca-agent/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "parca-agent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else if contains .Release.Name $name -}}
+{{- $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "parca-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "parca-agent.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Generate labels to be used
+*/}}
+{{- define "parca-agent.labels" -}}
+app: {{ include "parca-agent.fullname" . }}
+chart: {{ template "parca-agent.chart" . }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+{{- end }}
+
+{{- define "parca-agent-helm.labels" -}}
+{{ include "parca-agent.labels" . }}
+app.kubernetes.io/name: "parca-agent"
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/component: "observability"
+app.kubernetes.io/instance: {{ include "parca-agent.fullname" . | quote }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "parca-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "parca-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/parca-agent/templates/cluster-role-binding.yaml
+++ b/charts/parca-agent/templates/cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "parca-agent.fullname" . }}
+  labels:
+{{- include "parca-agent-helm.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "parca-agent.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "parca-agent.serviceAccountName" . }}
+  namespace: {{ template "parca-agent.namespace" . }}

--- a/charts/parca-agent/templates/cluster-role.yaml
+++ b/charts/parca-agent/templates/cluster-role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "parca-agent.fullname" . }}
+  labels:
+{{- include "parca-agent-helm.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/charts/parca-agent/templates/daemonset.yaml
+++ b/charts/parca-agent/templates/daemonset.yaml
@@ -1,0 +1,121 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "parca-agent.fullname" . }}
+  namespace: {{ template "parca-agent.namespace" . }}
+  labels:
+{{- include "parca-agent-helm.labels" . | nindent 4 }}
+  {{- if .Values.annotations }}
+  annotations: {{ toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "parca-agent.fullname" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+{{- include "parca-agent-helm.labels" . | nindent 8 }}
+      annotations:
+        {{- if .Values.podAnnotations }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+    spec:
+      containers:
+        - image: {{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: parca-agent
+          args:
+          - /bin/parca-agent
+          - --http-address=:7071
+          - --node=$(NODE_NAME)
+          {{- with .Values.extraArgs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          {{- if .Values.extraEnv }}
+            {{- range $.Values.extraEnv }}
+            - name: {{ .name }}
+              value: {{ tpl (.value | quote) $ }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: 7071
+              name: http
+          readinessProbe:
+          {{- toYaml .Values.readinessProbe | nindent 12 }}
+          livenessProbe:
+          {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- with .Values.podSecurityContext }}
+          securityContext: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /run
+              name: run
+            - mountPath: /boot
+              name: boot
+              readOnly: true
+            - mountPath: /lib/modules
+              name: modules
+            - mountPath: /sys/kernel/debug
+              name: debugfs
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+            - mountPath: /sys/fs/bpf
+              name: bpffs
+            - mountPath: /var/run/dbus/system_bus_socket
+              name: dbus-system
+          {{- if .Values.extraVolumeMounts }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+      volumes:
+        - emptyDir: {}
+          name: tmp
+        - hostPath:
+            path: /run
+          name: run
+        - hostPath:
+            path: /boot
+          name: boot
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroup
+        - hostPath:
+            path: /lib/modules
+          name: modules
+        - hostPath:
+            path: /sys/fs/bpf
+          name: bpffs
+        - hostPath:
+            path: /sys/kernel/debug
+          name: debugfs
+        - hostPath:
+            path: /var/run/dbus/system_bus_socket
+          name: dbus-system
+      {{- if .Values.extraVolumes }}
+      {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
+      hostPID: true
+      serviceAccountName: {{ include "parca-agent.serviceAccountName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/parca-agent/templates/pod-security-policy.yaml
+++ b/charts/parca-agent/templates/pod-security-policy.yaml
@@ -1,0 +1,41 @@
+{{ if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "parca-agent.fullname" . }}-policy
+  namespace: {{ template "parca-agent.namespace" . }}
+  labels:
+{{- include "parca-agent-helm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: policy
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - '*'
+  allowedHostPaths:
+    - pathPrefix: /sys
+    - pathPrefix: /boot
+    - pathPrefix: /var/run/dbus
+    - pathPrefix: /run
+    - pathPrefix: /lib/modules
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  privileged: true
+  readOnlyRootFilesystem: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - configMap
+    - emptyDir
+    - projected
+    - secret
+    - downwardAPI
+    - persistentVolumeClaim
+    - hostPath
+{{ end }}

--- a/charts/parca-agent/templates/role.yaml
+++ b/charts/parca-agent/templates/role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "parca-agent.fullname" . }}
+  namespace: {{ template "parca-agent.namespace" . }}
+  labels:
+{{- include "parca-agent-helm.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ include "parca-agent.fullname" . }}-policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/charts/parca-agent/templates/rolebinding.yaml
+++ b/charts/parca-agent/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "parca-agent.fullname" . }}
+  namespace: {{ template "parca-agent.namespace" . }}
+  labels:
+{{- include "parca-agent-helm.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "parca-agent.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "parca-agent.serviceAccountName" . }}

--- a/charts/parca-agent/templates/service-acccount.yaml
+++ b/charts/parca-agent/templates/service-acccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "parca-agent.serviceAccountName" . }}
+  namespace: {{ template "parca-agent.namespace" . }}
+  labels:
+{{- include "parca-agent-helm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/parca-agent/templates/service.yaml
+++ b/charts/parca-agent/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "parca-agent.fullname" . }}
+  namespace: {{ include "parca-agent.namespace" . }}
+  labels:
+{{- include "parca-agent-helm.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- .Values.service.annotations | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    app: {{ include "parca-agent.fullname" . }}
+    release: {{ .Release.Name }}
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    port: {{ .Values.service.port }}
+    targetPort: http
+    protocol: TCP
+    {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
+{{- if .Values.service.spec }}
+{{- .Values.service.spec | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/parca-agent/values.yaml
+++ b/charts/parca-agent/values.yaml
@@ -1,0 +1,102 @@
+image:
+  repository: ghcr.io/parca-dev/parca-agent
+  tag: "{{ .Chart.AppVersion }}"
+  pullPolicy: IfNotPresent
+
+# Override the namespace for all objects
+namespaceOverride: ""
+
+# Arguments that will be passed onto daemonset pods
+extraArgs:
+  - --log-level=info
+  - --debuginfo-strip
+  - --debuginfo-temp-dir=/tmp
+  - --debuginfo-upload-cache-duration=5m
+  # Use the following args to configure the address for Parca Server.
+  # - --remote-store-address=parca-server.parca.svc.cluster.local:7070
+  # - --remote-store-insecure
+  # - --remote-store-insecure-skip-verify
+
+# Environment variables that will be passed onto daemonset pods
+extraEnv: []
+
+# Extra volumes to be able to add extra files like certificates for example, to start a TLS server.
+# More info about volumes: https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumes: []
+#   - name: certs
+#     configMap:
+#       name: parca-tls-certs
+
+extraVolumeMounts: []
+#   - name: parca-tls-certs
+#     mountPath: "/etc/parca-agent/tls"
+#     readOnly: true
+
+# Annotations to be added to the parca-agent DaemonSet
+annotations: {}
+
+# Annotations to be added to the parca-agent Pods
+podAnnotations: {}
+
+# Set custom resource limits.
+resources: {}
+
+# Set custom security context for parca-server pods.
+podSecurityContext:
+  privileged: true
+  readOnlyRootFilesystem: true
+
+# Values for defining the Kubernetes Service.
+service:
+  # One of (ClusterIP | LoadBalancer | NodePort).
+  type: ClusterIP
+  # The port used by the service.
+  port: 7071
+  # Optional NodePort, only used for type `NodePort`.
+  nodePort: null
+  # Additional labels to be added to the Service.
+  labels: {}
+  # Additional annotations to be added to the Service.
+  annotations: {}
+  # Define extra fields to be interpolated into the Service spec.
+  #
+  # This allows for adding support for new features and functionality which may not yet
+  # be directly supported in this chart.
+  spec: {}
+  # loadBalancerSourceRanges:
+  # - "0.0.0.0/0"
+
+podSecurityPolicy:
+  enabled: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  # A map of annotations to be set on the ServiceAccount
+  annotations: {}
+
+# Set a custom readiness probe e.g. when basic auth is enabled.
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: http
+
+# Set a custom liveness probe e.g. when basic auth is enabled.
+livenessProbe:
+  httpGet:
+    path: /healthy
+    port: http
+
+# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+nodeSelector:
+  kubernetes.io/os: linux
+
+# https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations:
+  - operator: Exists
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR adds a helm chart for parca-agent. Together with the parca-server helm chart (#496) this can be used to deploy continuous profiling cluster wide.


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
