### PR TITLE
Expose avalanche service monitor interval

### DIFF
--- a/charts/avalanche/Chart.yaml
+++ b/charts/avalanche/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: avalanche
 description: A Helm chart run avalanche for benchmarking Prometheus and remote write storage backends.
-version: 0.7.0
+version: 0.8.0
 
 home: https://github.com/timescale/helm-charts
 

--- a/charts/avalanche/templates/service-monitor.yaml
+++ b/charts/avalanche/templates/service-monitor.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "avalanche-helm.labels" . | indent 4 }}
 spec:
   endpoints:
-  - interval: 30s
+  - interval: {{ .Values.serviceMonitor.interval }}
     port: metrics
     path: /metrics
   selector:

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -51,6 +51,7 @@ labels: {}
 # generated as load and intended for benchmarking.
 serviceMonitor:
   enabled: false
+  interval: 30s
 
 # Number of fake ServiceMonitor to be created to simulate fake Prometheus
 # targets. This will be useful to generate more series without scaling


### PR DESCRIPTION
Exposing this field would be useful to increase the number of samples being ingested into prometheus without incrasing the number of series.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it



#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart Version bumped
- [X] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
