### PR TITLE
Static location for environment variables files

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.26.2
+version: 0.26.3
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -50,10 +50,6 @@ Create the name of the service account to use.
 {{- end -}}
 {{- end -}}
 
-{{- define "pgbackrest_environment_file" -}}
-${HOME}/.pgbackrest_environment
-{{- end -}}
-
 {{- define "pgbackrest_bootstrap_environment_dir" -}}
 /etc/pgbackrest/bootstrap
 {{- end -}}

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -50,10 +50,6 @@ Create the name of the service account to use.
 {{- end -}}
 {{- end -}}
 
-{{- define "pod_environment_file" -}}
-${HOME}/.pod_environment
-{{- end -}}
-
 {{- define "pgbackrest_environment_file" -}}
 ${HOME}/.pgbackrest_environment
 {{- end -}}

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -85,7 +85,11 @@ data:
     # PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
     [ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
 
-    . "{{ template "pod_environment_file" }}"
+    : "${ENV_FILE:=${HOME}/.pod_environment}"
+    if [ -f "${ENV_FILE}" ]; then
+      echo "Sourcing ${ENV_FILE}"
+      . "${ENV_FILE}"
+    fi
 
     PGDATA={{ include "data_directory" . | quote }}
     WALDIR={{ include "wal_directory" . | quote }}
@@ -100,7 +104,11 @@ data:
   restore_or_initdb.sh: |
     #!/bin/sh
 
-    . "{{ template "pod_environment_file" }}"
+    : "${ENV_FILE:=${HOME}/.pod_environment}"
+    if [ -f "${ENV_FILE}" ]; then
+      echo "Sourcing ${ENV_FILE}"
+      . "${ENV_FILE}"
+    fi
 
     log() {
         echo "$(date '+%Y-%m-%d %H:%M:%S') - restore_or_initdb - $1"
@@ -214,7 +222,11 @@ data:
     echo "include_if_exists = '{{ template "tstune_config". }}'" >> "${PGDATA}/postgresql.conf"
   post_init.sh: |
     #!/bin/sh
-    . "{{ template "pod_environment_file" }}"
+    : "${ENV_FILE:=${HOME}/.pod_environment}"
+    if [ -f "${ENV_FILE}" ]; then
+      echo "Sourcing ${ENV_FILE}"
+      . "${ENV_FILE}"
+    fi
 
     log() {
         echo "$(date '+%Y-%m-%d %H:%M:%S') - post_init - $1"
@@ -291,7 +303,11 @@ data:
     #!/bin/sh
     set -e
 
-    . "{{ template "pod_environment_file" }}"
+    : "${ENV_FILE:=${HOME}/.pod_environment}"
+    if [ -f "${ENV_FILE}" ]; then
+      echo "Sourcing ${ENV_FILE}"
+      . "${ENV_FILE}"
+    fi
 
     for suffix in "$1" all
     do

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -33,14 +33,23 @@ data:
     PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
     [ ${PGBACKREST_BACKUP_ENABLED} -ne 0 ] || exit 0
 
-    . "{{ template "pgbackrest_environment_file" }}"
+    : "${ENV_FILE:=${HOME}/.pgbackrest_environment}"
+    if [ -f "${ENV_FILE}" ]; then
+      echo "Sourcing ${ENV_FILE}"
+      . "${ENV_FILE}"
+    fi
+
     exec pgbackrest --stanza=poddb archive-push "$@"
   pgbackrest_archive_get.sh: |
     #!/bin/sh
     # PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
     [ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
 
-    . "{{ template "pgbackrest_environment_file" }}"
+    : "${ENV_FILE:=${HOME}/.pgbackrest_environment}"
+    if [ -f "${ENV_FILE}" ]; then
+      echo "Sourcing ${ENV_FILE}"
+      . "${ENV_FILE}"
+    fi
     exec pgbackrest --stanza=poddb archive-get "${1}" "${2}"
   pgbackrest_bootstrap.sh: |
     #!/bin/sh

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -37,8 +37,8 @@ data:
     exec pgbackrest --stanza=poddb archive-push "$@"
   pgbackrest_archive_get.sh: |
     #!/bin/sh
-    PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
-    [ ${PGBACKREST_BACKUP_ENABLED} -ne 0 ] || exit 1
+    # PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
+    [ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
 
     . "{{ template "pgbackrest_environment_file" }}"
     exec pgbackrest --stanza=poddb archive-get "${1}" "${2}"
@@ -82,8 +82,8 @@ data:
     exec python3 /scripts/pgbackrest-rest.py --stanza=poddb --loglevel=debug
   pgbackrest_restore.sh: |
     #!/bin/sh
-    PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
-    [ ${PGBACKREST_BACKUP_ENABLED} -ne 0 ] || exit 1
+    # PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
+    [ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
 
     . "{{ template "pod_environment_file" }}"
 

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -217,6 +217,8 @@ spec:
           value: "/var/run/postgresql"
         - name: BOOTSTRAP_FROM_BACKUP
           value: {{ .Values.bootstrapFromBackup.enabled | int | quote }}
+        - name: PGBACKREST_BACKUP_ENABLED
+          value: {{ .Values.backup.enabled | quote }}
         {{- if .Values.env }}{{ .Values.env | default list | toYaml | nindent 8 }}{{- end }}
           # pgBackRest is also called using the archive_command if the backup is enabled.
           # this script will also need access to the environment variables specified for

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -152,7 +152,7 @@ spec:
             # to have the environment available to them
             set -o posix
             export -p > "${HOME}/.pod_environment"
-            export -p | grep PGBACKREST > "{{ template "pgbackrest_environment_file" }}"
+            export -p | grep PGBACKREST > "${HOME}/.pgbackrest_environment"
 
             for UNKNOWNVAR in $(env | awk -F '=' '!/^(PATRONI_.*|HOME|PGDATA|PGHOST|LC_.*|LANG|PATH|KUBERNETES_SERVICE_.*|AWS_ROLE_ARN|AWS_WEB_IDENTITY_TOKEN_FILE)=/ {print $1}')
             do

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -151,7 +151,7 @@ spec:
             # We store the current environment, as initscripts, callbacks, archive_commands etc. may require
             # to have the environment available to them
             set -o posix
-            export -p > "{{ template "pod_environment_file" }}"
+            export -p > "${HOME}/.pod_environment"
             export -p | grep PGBACKREST > "{{ template "pgbackrest_environment_file" }}"
 
             for UNKNOWNVAR in $(env | awk -F '=' '!/^(PATRONI_.*|HOME|PGDATA|PGHOST|LC_.*|LANG|PATH|KUBERNETES_SERVICE_.*|AWS_ROLE_ARN|AWS_WEB_IDENTITY_TOKEN_FILE)=/ {print $1}')


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR is an attempt to reduce code parametrization (effort needed to move some scripts out of a ConfigMap). It is done by statically reading ENV_FILE in each script. In the long term this will also allow to execute script with arbitrary file path, which is useful for development, as follows:
```
ENV_FILE="<path_to_file>" <script_name>.sh
```

This PR is part of effort from https://github.com/timescale/helm-charts/pull/505

PR is blocked by https://github.com/timescale/helm-charts/pull/515 and #516 

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
