### PR TITLE
Move patroni and pgbackrest scripts

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.26.3
+version: 0.26.4
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/scripts/patroni_callback.sh
+++ b/charts/timescaledb-single/scripts/patroni_callback.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+: "${ENV_FILE:=${HOME}/.pod_environment}"
+if [ -f "${ENV_FILE}" ]; then
+    echo "Sourcing ${ENV_FILE}"
+    . "${ENV_FILE}"
+fi
+
+for suffix in "$1" all
+do
+    CALLBACK="/etc/timescaledb/callbacks/${suffix}"
+    if [ -f "${CALLBACK}" ]
+    then
+    "${CALLBACK}" "$@"
+    fi
+done

--- a/charts/timescaledb-single/scripts/pgbackrest_archive_get.sh
+++ b/charts/timescaledb-single/scripts/pgbackrest_archive_get.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
+[ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
+
+: "${ENV_FILE:=${HOME}/.pgbackrest_environment}"
+if [ -f "${ENV_FILE}" ]; then
+echo "Sourcing ${ENV_FILE}"
+. "${ENV_FILE}"
+fi
+
+exec pgbackrest --stanza=poddb archive-get "${1}" "${2}"

--- a/charts/timescaledb-single/scripts/pgbackrest_bootstrap.sh
+++ b/charts/timescaledb-single/scripts/pgbackrest_bootstrap.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -e
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - bootstrap - $1"
+}
+
+terminate() {
+    log "Stopping"
+    exit 1
+}
+# If we don't catch these signals, and we're still waiting for PostgreSQL
+# to be ready, we will not respond at all to a regular shutdown request,
+# therefore, we explicitly terminate if we receive these signals.
+trap terminate TERM QUIT
+
+while ! pg_isready -q; do
+    log "Waiting for PostgreSQL to become available"
+    sleep 3
+done
+
+# We'll be lazy; we wait for another while to allow the database to promote
+# to primary if it's the only one running
+sleep 10
+
+# If we are the primary, we want to create/validate the backup stanza
+if [ "$(psql -c "SELECT pg_is_in_recovery()::text" -AtXq)" = "false" ]; then
+    pgbackrest check || {
+        log "Creating pgBackrest stanza"
+        pgbackrest --stanza=poddb stanza-create --log-level-stderr=info || exit 1
+        log "Creating initial backup"
+        pgbackrest --type=full backup || exit 1
+    }
+fi
+
+log "Starting pgBackrest api to listen for backup requests"
+exec python3 /scripts/pgbackrest-rest.py --stanza=poddb --loglevel=debug

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -40,17 +40,8 @@ data:
     fi
 
     exec pgbackrest --stanza=poddb archive-push "$@"
-  pgbackrest_archive_get.sh: |
-    #!/bin/sh
-    # PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
-    [ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
-
-    : "${ENV_FILE:=${HOME}/.pgbackrest_environment}"
-    if [ -f "${ENV_FILE}" ]; then
-      echo "Sourcing ${ENV_FILE}"
-      . "${ENV_FILE}"
-    fi
-    exec pgbackrest --stanza=poddb archive-get "${1}" "${2}"
+  pgbackrest_archive_get.sh: |-
+    {{- .Files.Get "scripts/pgbackrest_archive_get.sh" | nindent 4 }}
   pgbackrest_bootstrap.sh: |-
     {{- .Files.Get "scripts/pgbackrest_bootstrap.sh" | nindent 4 }}
   pgbackrest_restore.sh: |

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -308,24 +308,8 @@ data:
 
     # We exit 0 this script, otherwise the database initialization fails.
     exit 0
-  patroni_callback.sh: |
-    #!/bin/sh
-    set -e
-
-    : "${ENV_FILE:=${HOME}/.pod_environment}"
-    if [ -f "${ENV_FILE}" ]; then
-      echo "Sourcing ${ENV_FILE}"
-      . "${ENV_FILE}"
-    fi
-
-    for suffix in "$1" all
-    do
-      CALLBACK="{{ template "callbacks_dir" .}}/${suffix}"
-      if [ -f "${CALLBACK}" ]
-      then
-        "${CALLBACK}" "$@"
-      fi
-    done
+  patroni_callback.sh: |-
+    {{- .Files.Get "scripts/patroni_callback.sh" | nindent 4 }}
   lifecycle_preStop.psql: |-
     {{- .Files.Get "scripts/prestop.psql" | nindent 4 }}
 ...

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -51,44 +51,8 @@ data:
       . "${ENV_FILE}"
     fi
     exec pgbackrest --stanza=poddb archive-get "${1}" "${2}"
-  pgbackrest_bootstrap.sh: |
-    #!/bin/sh
-    set -e
-
-    log() {
-        echo "$(date '+%Y-%m-%d %H:%M:%S') - bootstrap - $1"
-    }
-
-    terminate() {
-        log "Stopping"
-        exit 1
-    }
-    # If we don't catch these signals, and we're still waiting for PostgreSQL
-    # to be ready, we will not respond at all to a regular shutdown request,
-    # therefore, we explicitly terminate if we receive these signals.
-    trap terminate TERM QUIT
-
-    while ! pg_isready -q; do
-        log "Waiting for PostgreSQL to become available"
-        sleep 3
-    done
-
-    # We'll be lazy; we wait for another while to allow the database to promote
-    # to primary if it's the only one running
-    sleep 10
-
-    # If we are the primary, we want to create/validate the backup stanza
-    if [ "$(psql -c "SELECT pg_is_in_recovery()::text" -AtXq)" = "false" ]; then
-        pgbackrest check || {
-            log "Creating pgBackrest stanza"
-            pgbackrest --stanza=poddb stanza-create --log-level-stderr=info || exit 1
-            log "Creating initial backup"
-            pgbackrest --type=full backup || exit 1
-        }
-    fi
-
-    log "Starting pgBackrest api to listen for backup requests"
-    exec python3 /scripts/pgbackrest-rest.py --stanza=poddb --loglevel=debug
+  pgbackrest_bootstrap.sh: |-
+    {{- .Files.Get "scripts/pgbackrest_bootstrap.sh" | nindent 4 }}
   pgbackrest_restore.sh: |
     #!/bin/sh
     # PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Moving scripts out of being embedded in a ConfigMap template to a separate directory to allow easier code maintenance.

Following scripts are moved:
- patroni_callback.sh
- pgbackrest_bootstrap.sh
- pgbackrest_archive_get.sh

This PR is part of effort from https://github.com/timescale/helm-charts/pull/505

PR is blocked by https://github.com/timescale/helm-charts/pull/515, https://github.com/timescale/helm-charts/pull/516, and #517

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
