### PR TITLE
Pgbackrest scripts migration

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.26.5
+version: 0.26.6
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/scripts/pgbackrest_archive.sh
+++ b/charts/timescaledb-single/scripts/pgbackrest_archive.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# If no backup is configured, archive_command would normally fail. A failing archive_command on a cluster
+# is going to cause WAL to be kept around forever, meaning we'll fill up Volumes we have quite quickly.
+#
+# Therefore, if the backup is disabled, we always return exitcode 0 when archiving
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - archive - $1"
+}
+
+[ -z "$1" ] && log "Usage: $0 <WALFILE or DIRECTORY>" && exit 1
+
+: "${ENV_FILE:=${HOME}/.pgbackrest_environment}"
+if [ -f "${ENV_FILE}" ]; then
+    echo "Sourcing ${ENV_FILE}"
+    . "${ENV_FILE}"
+fi
+
+# PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
+[ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 0
+
+exec pgbackrest --stanza=poddb archive-push "$@"

--- a/charts/timescaledb-single/scripts/pgbackrest_restore.sh
+++ b/charts/timescaledb-single/scripts/pgbackrest_restore.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
+[ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
+
+: "${ENV_FILE:=${HOME}/.pod_environment}"
+if [ -f "${ENV_FILE}" ]; then
+echo "Sourcing ${ENV_FILE}"
+. "${ENV_FILE}"
+fi
+
+# PGDATA and WALDIR are set in the StatefulSet template and are sourced from the ENV_FILE
+# PGDATA=
+# WALDIR=
+
+# A missing PGDATA points to Patroni removing a botched PGDATA, or manual
+# intervention. In this scenario, we need to recreate the DATA and WALDIRs
+# to keep pgBackRest happy
+[ -d "${PGDATA}" ] || install -o postgres -g postgres -d -m 0700 "${PGDATA}"
+[ -d "${WALDIR}" ] || install -o postgres -g postgres -d -m 0700 "${WALDIR}"
+
+exec pgbackrest --force --delta --log-level-console=detail restore

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -17,30 +17,8 @@ metadata:
 data:
   tstune.sh: |-
     {{- .Files.Get "scripts/tstune.sh" | nindent 4 }}
-  pgbackrest_archive.sh: |
-    #!/bin/sh
-
-    # If no backup is configured, archive_command would normally fail. A failing archive_command on a cluster
-    # is going to cause WAL to be kept around forever, meaning we'll fill up Volumes we have quite quickly.
-    #
-    # Therefore, if the backup is disabled, we always return exitcode 0 when archiving
-
-    log() {
-        echo "$(date '+%Y-%m-%d %H:%M:%S') - archive - $1"
-    }
-
-    [ -z "$1" ] && log "Usage: $0 <WALFILE or DIRECTORY>" && exit 1
-
-    PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
-    [ ${PGBACKREST_BACKUP_ENABLED} -ne 0 ] || exit 0
-
-    : "${ENV_FILE:=${HOME}/.pgbackrest_environment}"
-    if [ -f "${ENV_FILE}" ]; then
-      echo "Sourcing ${ENV_FILE}"
-      . "${ENV_FILE}"
-    fi
-
-    exec pgbackrest --stanza=poddb archive-push "$@"
+  pgbackrest_archive.sh: |-
+    {{- .Files.Get "scripts/pgbackrest_archive.sh" | nindent 4 }}
   pgbackrest_archive_get.sh: |-
     {{- .Files.Get "scripts/pgbackrest_archive_get.sh" | nindent 4 }}
   pgbackrest_bootstrap.sh: |-

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -17,12 +17,13 @@ metadata:
 data:
   tstune.sh: |-
     {{- .Files.Get "scripts/tstune.sh" | nindent 4 }}
-  # If no backup is configured, archive_command would normally fail. A failing archive_command on a cluster
-  # is going to cause WAL to be kept around forever, meaning we'll fill up Volumes we have quite quickly.
-  #
-  # Therefore, if the backup is disabled, we always return exitcode 0 when archiving
   pgbackrest_archive.sh: |
     #!/bin/sh
+
+    # If no backup is configured, archive_command would normally fail. A failing archive_command on a cluster
+    # is going to cause WAL to be kept around forever, meaning we'll fill up Volumes we have quite quickly.
+    #
+    # Therefore, if the backup is disabled, we always return exitcode 0 when archiving
 
     log() {
         echo "$(date '+%Y-%m-%d %H:%M:%S') - archive - $1"
@@ -45,26 +46,7 @@ data:
   pgbackrest_bootstrap.sh: |-
     {{- .Files.Get "scripts/pgbackrest_bootstrap.sh" | nindent 4 }}
   pgbackrest_restore.sh: |
-    #!/bin/sh
-    # PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
-    [ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
-
-    : "${ENV_FILE:=${HOME}/.pod_environment}"
-    if [ -f "${ENV_FILE}" ]; then
-      echo "Sourcing ${ENV_FILE}"
-      . "${ENV_FILE}"
-    fi
-
-    PGDATA={{ include "data_directory" . | quote }}
-    WALDIR={{ include "wal_directory" . | quote }}
-
-    # A missing PGDATA points to Patroni removing a botched PGDATA, or manual
-    # intervention. In this scenario, we need to recreate the DATA and WALDIRs
-    # to keep pgBackRest happy
-    [ -d "${PGDATA}" ] || install -o postgres -g postgres -d -m 0700 "${PGDATA}"
-    [ -d "${WALDIR}" ] || install -o postgres -g postgres -d -m 0700 "${WALDIR}"
-
-    exec pgbackrest --force --delta --log-level-console=detail restore
+    {{- .Files.Get "scripts/pgbackrest_restore.sh" | nindent 4 }}
   restore_or_initdb.sh: |
     #!/bin/sh
 

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -219,6 +219,8 @@ spec:
           value: "$(PATRONI_POSTGRESQL_DATA_DIR)"
         - name: PGHOST
           value: "/var/run/postgresql"
+        - name: WALDIR
+          value: {{ include "wal_directory" . | quote }}
         - name: BOOTSTRAP_FROM_BACKUP
           value: {{ .Values.bootstrapFromBackup.enabled | int | quote }}
         - name: PGBACKREST_BACKUP_ENABLED


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Moving and slightly refactoring (note new WALDIR environment variable) pgbackrest_archive.sh and pgbackrest_restore.sh scripts out of being embedded in a ConfigMap template to a separate directory to allow easier code maintenance.

This PR is part of effort from https://github.com/timescale/helm-charts/pull/505

PR is blocked by https://github.com/timescale/helm-charts/pull/515, https://github.com/timescale/helm-charts/pull/516,  https://github.com/timescale/helm-charts/pull/517, #518, and #519

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
