### PR TITLE
charts/timescaledb-single: improve topology handling

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.27.5
+version: 0.28.0
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/docs/admin-guide.md
+++ b/charts/timescaledb-single/docs/admin-guide.md
@@ -22,7 +22,6 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 |       Parameter                   |           Description                       |                         Default                     |
 |-----------------------------------|---------------------------------------------|-----------------------------------------------------|
 | `affinity`                        | Affinity settings. Overrides `affinityTemplate` if set. | `{}`                                    |
-| `affinityTemplate`                | A template string to use to generate the affinity settings | Anti-affinity preferred on hostname and (availability) zone |
 | `backup.enabled`                  | Schedule backups to occur                   | `false`                                             |
 | `backup.jobs`                     | A list of backup schedules and types        | 1 full weekly backup, 1 incremental daily backup    |
 | `backup.pgBackRest:archive-get`   | [pgBackRest global:archive-get configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)  | empty |

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -456,13 +456,14 @@ spec:
     {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName }}
     {{- end }}
+    {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
     {{- if .Values.affinity }}
       affinity:
-        {{ .Values.affinity | toYaml | nindent 8 }}
-    {{- else if .Values.affinityTemplate }}
-      affinity:
-        {{ tpl .Values.affinityTemplate . | nindent 8 }}
-    {{- end }}
+        {{- .Values.affinity | toYaml | nindent 8 }}
+      {{- end }}
       volumes:
       - name: socket-directory
         emptyDir: {}

--- a/charts/timescaledb-single/values.schema.json
+++ b/charts/timescaledb-single/values.schema.json
@@ -102,9 +102,6 @@
       "additionalProperties": true,
       "type": "object"
     },
-    "affinityTemplate": {
-      "type": "string"
-    },
     "backup": {
       "additionalProperties": false,
       "properties": {
@@ -778,6 +775,9 @@
     "tolerations": {
       "type": "array"
     },
+    "topologySpreadConstraints": {
+      "type": "array"
+    },
     "version": {
       "maximum": 14,
       "minimum": 11,
@@ -789,7 +789,6 @@
   },
   "required": [
     "affinity",
-    "affinityTemplate",
     "backup",
     "bootstrapFromBackup",
     "callbacks",
@@ -814,7 +813,8 @@
     "podMonitor",
     "sharedMemory",
     "timescaledbTune",
-    "tolerations"
+    "tolerations",
+    "topologySpreadConstraints"
   ],
   "schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/charts/timescaledb-single/values.schema.yaml
+++ b/charts/timescaledb-single/values.schema.yaml
@@ -11,7 +11,6 @@
 schema: http://json-schema.org/draft-07/schema#
 required:
   - affinity
-  - affinityTemplate
   - backup
   - bootstrapFromBackup
   - callbacks
@@ -37,6 +36,7 @@ required:
   - sharedMemory
   - timescaledbTune
   - tolerations
+  - topologySpreadConstraints
 additionalProperties: false
 properties:
   podMonitor:
@@ -422,6 +422,8 @@ properties:
     additionalProperties:
       type: string
   tolerations:
+    type: array
+  topologySpreadConstraints:
     type: array
   debug:
     type: object

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -542,26 +542,10 @@ podLabels: {}
 tolerations: []
 
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-affinityTemplate: |
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 100
-      podAffinityTerm:
-        topologyKey: "kubernetes.io/hostname"
-        labelSelector:
-          matchLabels:
-            app: {{ template "timescaledb.fullname" . }}
-            release: {{ .Release.Name | quote }}
-            cluster-name: {{ template "clusterName" . }}
-    - weight: 50
-      podAffinityTerm:
-        topologyKey: failure-domain.beta.kubernetes.io/zone
-        labelSelector:
-          matchLabels:
-            app: {{ template "timescaledb.fullname" . }}
-            release: {{ .Release.Name | quote }}
-            cluster-name: {{ template "clusterName" . }}
 affinity: {}
+
+# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#topologyspreadconstraints
+topologySpreadConstraints: []
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/


### PR DESCRIPTION
Adding topologySpreadConstraints and removing `affinityTemplate` to allow easier handling of topology spread.

Defaulting to kubernetes defaults when it comes to handling topology

Signed-off-by: Paweł Krupa (paulfantom) <pawel@krupa.net.pl>

<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

- Removal of `affinityTemplate` to allow only one way of setting affinity (via `affinity` field). This should simplify UX.
- Removing default affinity settings as the same is default in kubernetes 1.24+
- Adding option to set `topologySpreadConstraints`

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
