### PR TITLE
charts/timescaledb-single: allow setting affinity

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.26.8
+version: 0.26.9
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/values.schema.json
+++ b/charts/timescaledb-single/values.schema.json
@@ -99,7 +99,7 @@
   },
   "properties": {
     "affinity": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "type": "object"
     },
     "affinityTemplate": {

--- a/charts/timescaledb-single/values.schema.yaml
+++ b/charts/timescaledb-single/values.schema.yaml
@@ -175,7 +175,7 @@ properties:
           type: string
   affinity:
     type: object
-    additionalProperties: false
+    additionalProperties: true
   affinityTemplate:
     type: string
   serviceAccount:


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Currently schema validation prevents usage of `affinity` field with error like the following one:
```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
timescaledb-single:
- affinity: Additional property nodeAffinity is not allowed
- affinity: Additional property podAntiAffinity is not allowed
```

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #465

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart Version bumped
- [ ] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
