### PR TITLE
Add support to configure `scrapeTimeout` for Prometheus

### DIFF
--- a/charts/avalanche/Chart.yaml
+++ b/charts/avalanche/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: avalanche
 description: A Helm chart run avalanche for benchmarking Prometheus and remote write storage backends.
-version: 0.8.0
+version: 0.8.1
 
 home: https://github.com/timescale/helm-charts
 

--- a/charts/avalanche/templates/service-monitor.yaml
+++ b/charts/avalanche/templates/service-monitor.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   endpoints:
   - interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     port: metrics
     path: /metrics
   selector:


### PR DESCRIPTION

Signed-off-by: Harkishen Singh <harkishensingh@hotmail.com>

<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This commit allows to configure scrapeTimeout for Prometheus instances. This is particularly useful in benchmarks when scraping large targets with > 2M series, since then Prometheus needs more than 10s (default `scrapeTimeout`) to complete.

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
