### PR TITLE
Prevent helm 3.10.3 linting failure

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.27.4
+version: 0.27.5
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -22,7 +22,7 @@ spec:
 ...
 {{- range .Values.backup.jobs }}
 ---
-{{- if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion -}}
+{{ if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: batch/v1
 {{- else -}}
 apiVersion: batch/v1beta1


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Linting the timescaledb-single chart with a helm 3.10.3 fails. 
https://github.com/timescale/helm-charts/issues/542 provides additional details and a fix.

#### Which issue this PR fixes

- fixes #542

#### Special notes for your reviewer

None

#### Checklist

- [x] Chart Version bumped
- [X] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
