### PR TITLE
set patronictl config file

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,9 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.32.0
-icon: https://cdn.iconscout.com/icon/free/png-256/timescaledb-1958407-1651618.png
-
+version: 0.33.0
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
 version: 0.33.0
+icon: https://cdn.iconscout.com/icon/free/png-256/timescaledb-1958407-1651618.png
+
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -174,6 +174,8 @@ spec:
         # Where possible, we want to have lowercase usernames in PostgreSQL as more complex postgres usernames
         # requiring quoting to be done in certain contexts, which many tools do not do correctly, or even at all.
         # https://patroni.readthedocs.io/en/latest/ENVIRONMENT.html#bootstrap-configuration
+        - name: PATRONICTL_CONFIG_FILE
+          value: "/etc/timescaledb/patroni.yaml"
         - name: PATRONI_admin_OPTIONS
           value: createrole,createdb
         - name: PATRONI_REPLICATION_USERNAME


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Points patronictl to the correct config file.
This means that people can run the CLI without using `-c /etc/timescaledb/patroni.yaml`

#### Which issue this PR fixes

Minimizes the risk of mistakes such as

#179
#347
#418 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
