### PR TITLE
Add option to provide images used by jobs, bump chart version, update…

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,9 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.31.0
+version: 0.32.0
+icon: https://cdn.iconscout.com/icon/free/png-256/timescaledb-1958407-1651618.png
+
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/templates/job-update-patroni.yaml
+++ b/charts/timescaledb-single/templates/job-update-patroni.yaml
@@ -34,7 +34,8 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: {{ template "timescaledb.fullname" . }}-patch-patroni-config
-        image: curlimages/curl
+        image: "{{ .Values.curlImage.repository }}:{{ .Values.curlImage.tag }}"
+        imagePullPolicy: {{ .Values.curlImage.pullPolicy }}
         command: ["/bin/sh"]
         # Patching the Patroni configuration is good, however it should not block an upgrade from going through
         # Therefore we ensure we always exit with an exitcode 0, so that Helm is satisfied with this upgrade job

--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -55,7 +55,8 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: {{ template "timescaledb.fullname" $ }}-{{ .type }}
-              image: curlimages/curl
+              image: "{{ .Values.curlImage.repository }}:{{ .Values.curlImage.tag }}"
+              imagePullPolicy: {{ .Values.curlImage.pullPolicy }}
               command: ["/usr/bin/curl"]
               args:
               - --connect-timeout

--- a/charts/timescaledb-single/values.schema.json
+++ b/charts/timescaledb-single/values.schema.json
@@ -192,6 +192,28 @@
       "maxLength": 30,
       "type": "string"
     },
+    "curlImage": {
+      "additionalProperties": false,
+      "properties": {
+        "pullPolicy": {
+          "enum": [
+            "Always",
+            "Never",
+            "IfNotPresent"
+          ],
+          "type": "string"
+        },
+        "repository": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "tag": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "debug": {
       "additionalProperties": false,
       "properties": {
@@ -571,9 +593,6 @@
     "prometheus": {
       "additionalProperties": false,
       "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
         "args": {
           "items": {
             "type": "string"
@@ -582,6 +601,9 @@
             "array",
             "null"
           ]
+        },
+        "enabled": {
+          "type": "boolean"
         },
         "env": {
           "items": {
@@ -795,6 +817,7 @@
     "debug",
     "fullnameOverride",
     "image",
+    "curlImage",
     "networkPolicy",
     "nodeSelector",
     "patroni",

--- a/charts/timescaledb-single/values.schema.yaml
+++ b/charts/timescaledb-single/values.schema.yaml
@@ -17,6 +17,7 @@ required:
   - debug
   - fullnameOverride
   - image
+  - curlImage
   - networkPolicy
   - nodeSelector
   - patroni
@@ -176,8 +177,6 @@ properties:
   affinity:
     type: object
     additionalProperties: true
-  affinityTemplate:
-    type: string
   serviceAccount:
     type: object
     additionalProperties: false
@@ -496,6 +495,22 @@ properties:
           - object
           - "null"
   image:
+    type: object
+    additionalProperties: false
+    properties:
+      repository:
+        type: string
+        minLength: 1
+      tag:
+        type: string
+        minLength: 1
+      pullPolicy:
+        type: string
+        enum:
+          - Always
+          - Never
+          - IfNotPresent
+  curlImage:
     type: object
     additionalProperties: false
     properties:

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -23,6 +23,14 @@ image:
   tag: pg14.6-ts2.9.1-p1
   pullPolicy: Always
 
+# There are job and cronjob resources that run during updates or backups that use curl image
+# Users in that want to define their own curl image can set it below
+# Example: https://github.com/timescale/helm-charts/blob/main/charts/timescaledb-single/templates/job-update-patroni.yaml
+curlImage:
+  repository: curlimages/curl
+  tag: "7.87.0"
+  pullPolicy: Always
+
 # By default those secrets are randomly generated.
 # To prevent misconfiguration, modifications from helm upgrade won't be applied to those secrets.
 # As a result changing secrets cannot be done via helm and need manual intervention.


### PR DESCRIPTION
… schemas, add icon to remove helm lint warning

<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR does the following based off my requirements:
1. Make the job/cronjob image used by patroni configurable via `values.yaml` file
2. Removes warning from helm lint due to missing icon, included a direct link to timescaledb icon
3. Remove no longer specified field `affinityTemplate` in `values.schema.yaml`
4. Updates `values.schema.json` based off `gojsontoyaml` (version: v0.1.0 ) output
5. Bump chart version from `0.31.0` to `0.32.0`


#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #555 

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
