### PR TITLE
Fix/curl image regression in v0.32.0

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.33.0
+version: 0.33.1
 icon: https://cdn.iconscout.com/icon/free/png-256/timescaledb-1958407-1651618.png
 
 # appVersion specifies the version of the software, which can vary wildly,

--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -55,8 +55,8 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: {{ template "timescaledb.fullname" $ }}-{{ .type }}
-              image: "{{ .Values.curlImage.repository }}:{{ .Values.curlImage.tag }}"
-              imagePullPolicy: {{ .Values.curlImage.pullPolicy }}
+              image: "{{ $.Values.curlImage.repository }}:{{ $.Values.curlImage.tag }}"
+              imagePullPolicy: {{ $.Values.curlImage.pullPolicy }}
               command: ["/usr/bin/curl"]
               args:
               - --connect-timeout


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Fixes a regression in [v0.32.0](https://github.com/timescale/helm-charts/releases/tag/timescaledb-single-0.32.0)

https://github.com/timescale/helm-charts/pull/558/files#diff-6ab02d41d428afe61e042df370a3f7e6d8eb6d3d4341223dd62e5c5196d3d867R37

#### Which issue this PR fixes

There is a regression in v0.32.0 that results in this error when using the chart

`<.Values.curlImage.repository>: nil pointer evaluating interface {}.curlImage`

#### Special notes for your reviewer

The problem happens because the scope changes here:

https://github.com/timescale/helm-charts/blob/555e38331a21ed1e3ecc6782a51117afbaf899df/charts/timescaledb-single/templates/pgbackrest.yaml#L23

so `.Values` is not accesible anymore:

https://github.com/timescale/helm-charts/blob/555e38331a21ed1e3ecc6782a51117afbaf899df/charts/timescaledb-single/templates/pgbackrest.yaml#L58-L59

To fix this, it is necessary to prefix these values with `$`


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
