### PR TITLE
Use emptyDir for pgbackrest repo1-path

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.33.1
+version: 0.33.2
 icon: https://cdn.iconscout.com/icon/free/png-256/timescaledb-1958407-1651618.png
 
 # appVersion specifies the version of the software, which can vary wildly,

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -401,6 +401,8 @@ spec:
         - mountPath: /etc/pgbackrest_secrets
           name: pgbackrest-secrets
           readOnly: true
+        - mountPath: {{ index .Values.backup.pgBackRest "repo1-path" | default (printf "/%s/%s/" .Release.Namespace (include "clusterName" .)) | quote }}
+          name: pgbackrest-repo
         env:
           - name: PGHOST
             value: /var/run/postgresql
@@ -528,6 +530,10 @@ spec:
         secret:
           secretName: {{ .Values.bootstrapFromBackup.secretName }}
           optional: True
+      {{- if or .Values.backup.enabled .Values.backup.enable }}
+      - name: pgbackrest-repo
+        emptyDir: {}
+      {{- end }}
       {{- if not .Values.persistentVolumes.data.enabled }}
       - name: storage-volume
         emptyDir: {}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Creates the directory defined by `repo1-path`, to be used as the pgBackRest repository, as described in their user guide:
  https://pgbackrest.org/user-guide.html#quickstart/create-repository

Resolves this error during pgbackrest_bootstrap.sh:
```
ERROR: [103]: unable to find a valid repository:
       repo1: [FileMissingError] unable to load info file ...
```

#### Which issue this PR fixes
- fixes #545 

#### Special notes for your reviewer


#### Checklist
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
