### PR TITLE
check for enabled backup after sourcing environment

### DIFF
--- a/charts/timescaledb-single/scripts/pgbackrest_archive_get.sh
+++ b/charts/timescaledb-single/scripts/pgbackrest_archive_get.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
-# PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
-[ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
 
 : "${ENV_FILE:=${HOME}/.pgbackrest_environment}"
 if [ -f "${ENV_FILE}" ]; then
 echo "Sourcing ${ENV_FILE}"
 . "${ENV_FILE}"
 fi
+
+# PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
+[ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
 
 exec pgbackrest --stanza=poddb archive-get "${1}" "${2}"

--- a/charts/timescaledb-single/scripts/pgbackrest_restore.sh
+++ b/charts/timescaledb-single/scripts/pgbackrest_restore.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
-# PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
-[ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
 
 : "${ENV_FILE:=${HOME}/.pod_environment}"
 if [ -f "${ENV_FILE}" ]; then
 echo "Sourcing ${ENV_FILE}"
 . "${ENV_FILE}"
 fi
+
+# PGBACKREST_BACKUP_ENABLED variable is passed in StatefulSet template
+[ "${PGBACKREST_BACKUP_ENABLED}" = "true" ] || exit 1
 
 # PGDATA and WALDIR are set in the StatefulSet template and are sourced from the ENV_FILE
 # PGDATA=


### PR DESCRIPTION
#### What this PR does / why we need it

Recently, some heavy refactoring in the backup/restore procedure took place. This also changed the way how the environment variables etc were set up for the statefulset. 

With more recent helm chart versions, it is not possible anymore to restore a replica node from pgbackrest due to checking too early in script if backups are enabled or not. 

Furthermore, slaves are not able to fetch WAL from archive, leading to broken replicas (master already disposed WAL segment).

I ended up with a degraded cluster multiple times in the last weeks. This seems to fix it for me.


#### Which issue this PR fixes

- fixes #574

#### Checklist

- [ ] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
