### PR TITLE
Update semver to 0.33.2

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.33.1
+version: 0.33.2
 icon: https://cdn.iconscout.com/icon/free/png-256/timescaledb-1958407-1651618.png
 
 # appVersion specifies the version of the software, which can vary wildly,


### PR DESCRIPTION
Forgot to update the version update of the `timescale-single` chart in PR #581.
Updating it from 0.33.1 to 0.33.2 here.