### PR TITLE
charts/timescaledb-single: update timescaledb to 2.11.1

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.33.2
+version: 0.34.0
 icon: https://cdn.iconscout.com/icon/free/png-256/timescaledb-1958407-1651618.png
 
 # appVersion specifies the version of the software, which can vary wildly,

--- a/charts/timescaledb-single/docs/admin-guide.md
+++ b/charts/timescaledb-single/docs/admin-guide.md
@@ -35,7 +35,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `fullnameOverride`                | Override the fullname of the chart          | `nil`                                               |
 | `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
 | `image.repository`                | The image to pull                           | `timescale/timescaledb-ha`                       |
-| `image.tag`                       | The version of the image to pull            | `pg13-ts2.1-latest`
+| `image.tag`                       | The version of the image to pull            | `pg14.8-ts2.11.1`                                |
 | `service.primary.type`        | The service type to use for the primary service | `ClusterIP`                          |
 | `service.primary.port`        | The service port to use for the primary service | `5432`                               |
 | `service.primary.nodePort`    | The service nodePort to use for the primary service when `type` is `NodePort` | `null` |

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -20,7 +20,7 @@ image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescale/timescaledb-ha
-  tag: pg14.6-ts2.9.1-p1
+  tag: pg14.8-ts2.11.1
   pullPolicy: Always
 
 # There are job and cronjob resources that run during updates or backups that use curl image


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR updates the timescaledb image to 2.11.1. This image provides an updated patroni instance which fixes several permission issues.

#### Which issue this PR fixes

- fixes #604
- fixes #599
- supersedes #601
- supersedes #610

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
