### PR TITLE
Fixs #628 to bootstrap from backup

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.33.1
+version: 0.33.2
 icon: https://cdn.iconscout.com/icon/free/png-256/timescaledb-1958407-1651618.png
 
 # appVersion specifies the version of the software, which can vary wildly,

--- a/charts/timescaledb-single/docs/admin-guide.md
+++ b/charts/timescaledb-single/docs/admin-guide.md
@@ -146,6 +146,8 @@ For example:
     PGBACKREST_REPO1_S3_KEY_SECRET: <base64 encoded examplesecret+D48GXfDdtlnlSdmB>
   ```
 
+These values must be duplicated in the `backup.pgBackRest: {}` section regardless if `backup.enabled=true` otherwise the configuration at `/etc/pgbackrest/pgbackrest.conf` will not be able to bootstrap from backup.
+
 Another example, if you want to include encryption of your backups by pgBackRest, is to include these parameters:
 
 ```yaml

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -317,6 +317,8 @@ spec:
         - mountPath: /etc/pgbackrest/bootstrap
           name: pgbackrest-bootstrap
           readOnly: true
+        - mountPath: {{ index .Values.backup.pgBackRest "repo1-path" | default (printf "/%s/%s/" .Release.Namespace (include "clusterName" .)) | quote }}
+          name: pgbackrest-repo1-path
         resources:
           {{ toYaml .Values.resources | nindent 10 }}
 
@@ -401,6 +403,9 @@ spec:
         - mountPath: /etc/pgbackrest_secrets
           name: pgbackrest-secrets
           readOnly: true
+        - mountPath: {{ index .Values.backup.pgBackRest "repo1-path" | default (printf "/%s/%s/" .Release.Namespace (include "clusterName" .)) | quote }}
+          name: pgbackrest-repo1-path
+
         env:
           - name: PGHOST
             value: /var/run/postgresql
@@ -528,6 +533,8 @@ spec:
         secret:
           secretName: {{ .Values.bootstrapFromBackup.secretName }}
           optional: True
+      - name: pgbackrest-repo1-path
+        emptyDir: {}
       {{- if not .Values.persistentVolumes.data.enabled }}
       - name: storage-volume
         emptyDir: {}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR enables bootstrap from backup feature for a new deployment from an old deployment's S3 bucket backup.

fixes #628

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
