### PR TITLE
Assigning backup jobs to specific nodes

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.33.2
+version: 0.33.3
 icon: https://cdn.iconscout.com/icon/free/png-256/timescaledb-1958407-1651618.png
 
 # appVersion specifies the version of the software, which can vary wildly,

--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -71,6 +71,18 @@ spec:
               - |
                   {"type": {{ quote .type }}}
               - "http://{{ template "timescaledb.fullname" $ }}-backup:8081/backups/"
+          {{- with $.Values.backup.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.backup.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if $.Values.backup.affinity }}
+          affinity:
+            {{- $.Values.backup.affinity | toYaml | nindent 12 }}
+          {{- end }}
 ...
 {{- end }}
 {{ end }}

--- a/charts/timescaledb-single/values.schema.json
+++ b/charts/timescaledb-single/values.schema.json
@@ -120,6 +120,16 @@
             "null"
           ]
         },
+        "affinity": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
         "jobs": {
           "type": "array"
         },

--- a/charts/timescaledb-single/values.schema.yaml
+++ b/charts/timescaledb-single/values.schema.yaml
@@ -472,6 +472,13 @@ properties:
         type:
           - object
           - "null"
+    nodeSelector:
+      type: object
+    tolerations:
+      type: array
+    affinity:
+      type: object
+      additionalProperties: true
   secrets:
     type: object
     additionalProperties: false

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -147,6 +147,27 @@ backup:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+  # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  #  tolerations:
+  #    - key: node-group
+  #      operator: Equal
+  #      value: spot-job
+  tolerations: []
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  #  affinity:
+  #    nodeAffinity:
+  #      requiredDuringSchedulingIgnoredDuringExecution:
+  #        nodeSelectorTerms:
+  #          - matchExpressions:
+  #              - key: node-group
+  #                operator: In
+  #                values:
+  #                  - spot-job
+  affinity: {}
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  #  nodeSelector:
+  #    node-group: spot-job
+  nodeSelector: {}
 
 # When creating a *new* deployment, the default is to initialize (using initdb) the database.
 # If however, you want to initialize the database using an existing backup, you can do so by


### PR DESCRIPTION
<!--
Thank you for contributing to timescale/tobs.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR allows you to set sheduling rules for assinging pgbackrest jobs on certain node groups. This is useful when it is not possible to set PreferNoSchedule for nodes.
 User can assign job with `nodeSelector` `tolerations` and `affinity` rules.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
